### PR TITLE
Add game header fields

### DIFF
--- a/apps/admin/src/views/GameManagement.vue
+++ b/apps/admin/src/views/GameManagement.vue
@@ -81,6 +81,30 @@
         </div>
       </div>
       <div class="field">
+        <label class="label has-text-white">Game Header</label>
+        <div class="control">
+          <input v-model="newGame.gameHeader" class="input" type="text" placeholder="Header above pyramid" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Pool Header</label>
+        <div class="control">
+          <input v-model="newGame.poolHeader" class="input" type="text" placeholder="Header above image pool" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Wordt Header</label>
+        <div class="control">
+          <input v-model="newGame.wordtHeader" class="input" type="text" placeholder="Header for worst item" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Share Text</label>
+        <div class="control">
+          <input v-model="newGame.shareText" class="input" type="text" placeholder="Text used when sharing results" />
+        </div>
+      </div>
+      <div class="field">
         <label class="label has-text-white">Custom Data (JSON)</label>
         <div class="control">
           <textarea v-model="newGameCustom" class="textarea" placeholder='e.g., {"maxQuestions": 10}'></textarea>
@@ -162,7 +186,16 @@ const games = ref<Game[]>([]);
 const items = ref<ImageItem[]>([]);
 const newGameType = ref<GameType>({ id: '', name: '', description: '' });
 const newGameTypeCustom = ref<string>('');
-const newGame = ref<Game>({ id: '', name: '', description: '', gameTypeId: '' });
+const newGame = ref<Game>({
+  id: '',
+  name: '',
+  description: '',
+  gameTypeId: '',
+  gameHeader: '',
+  poolHeader: '',
+  wordtHeader: '',
+  shareText: '',
+});
 const newGameCustom = ref<string>('');
 const selectedGameTypeId = ref<string | null>(null);
 const selectedGameId = ref<string | null>(null);
@@ -325,11 +358,24 @@ const createGame = async () => {
       name: newGame.value.name,
       description: newGame.value.description,
       gameTypeId: selectedGameTypeId.value,
+      gameHeader: newGame.value.gameHeader,
+      poolHeader: newGame.value.poolHeader,
+      wordtHeader: newGame.value.wordtHeader,
+      shareText: newGame.value.shareText,
       custom: customData || { items: [] }, // Initialize with empty items array
     });
     success.value = `Game '${newGame.value.name}' created successfully`;
     console.log('Game created:', newGame.value);
-    newGame.value = { id: '', name: '', description: '', gameTypeId: '' };
+    newGame.value = {
+      id: '',
+      name: '',
+      description: '',
+      gameTypeId: '',
+      gameHeader: '',
+      poolHeader: '',
+      wordtHeader: '',
+      shareText: '',
+    };
     newGameCustom.value = '';
   } catch (err: any) {
     error.value = `Failed to create game: ${err.message}`;

--- a/apps/client/src/components/PyramidTable.vue
+++ b/apps/client/src/components/PyramidTable.vue
@@ -7,6 +7,8 @@
         </button>
       </div>
 
+      <h2 class="subtitle" :class="{ 'has-text-white': isDark }">{{ props.gameHeader }}</h2>
+
       <div class="pyramid" :class="{ dark: isDark }">
         <div v-for="(row, rowIndex) in pyramid" :key="rowIndex" class="pyramid-row">
           <div
@@ -36,7 +38,7 @@
 
       <!-- Worst Item Slot -->
       <div class="worst-item-container mt-4" :class="{ dark: isDark }">
-        <h3 class="subtitle has-text-centered" :class="{ 'has-text-white': isDark }">Worst Item</h3>
+        <h3 class="subtitle has-text-centered" :class="{ 'has-text-white': isDark }">{{ props.wordtHeader }}</h3>
         <div
           class="pyramid-slot box worst-slot"
           :class="[
@@ -59,7 +61,7 @@
         </div>
       </div>
 
-      <h2 class="subtitle mt-6" :class="{ 'has-text-white': isDark }">Image Pool</h2>
+      <h2 class="subtitle mt-6" :class="{ 'has-text-white': isDark }">{{ props.poolHeader }}</h2>
       <div
         class="image-pool drop-zone"
         :class="{ dark: isDark }"
@@ -89,9 +91,18 @@
 import { ref, watch } from 'vue';
 import { ImageItem, PyramidSlot, PyramidData } from '@top-x/shared/types/pyramid';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   items: ImageItem[];
-}>();
+  gameHeader?: string;
+  poolHeader?: string;
+  wordtHeader?: string;
+  shareText?: string;
+}>(), {
+  gameHeader: 'Your Pyramid',
+  poolHeader: 'Image Pool',
+  wordtHeader: 'Worst Item',
+  shareText: '',
+});
 
 const emit = defineEmits<{
   (e: 'submit', data: PyramidData): void;

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -11,5 +11,9 @@ export interface Game {
   name: string;
   description: string;
   gameTypeId: string;
+  gameHeader?: string;
+  poolHeader?: string;
+  wordtHeader?: string;
+  shareText?: string;
   custom?: Record<string, any>;
 }


### PR DESCRIPTION
## Summary
- extend `Game` type with header and share text fields
- update admin interface to manage new game fields
- allow `PyramidTable` to display customizable headers

## Testing
- `npm run build:shared` *(fails: npm could not access network)*

------
https://chatgpt.com/codex/tasks/task_b_6857ff677924832f998dff32e12a4c5f