### PR TITLE
Add active flag for games

### DIFF
--- a/apps/admin/src/components/GameList.vue
+++ b/apps/admin/src/components/GameList.vue
@@ -12,6 +12,7 @@
       <div v-for="game in games" :key="game.id" class="box">
         <h3 class="title is-5 has-text-white">{{ game.name }}</h3>
         <p class="has-text-grey-light">{{ game.description }}</p>
+        <p class="has-text-grey-light">Active: {{ game.active ? 'Yes' : 'No' }}</p>
         <div class="buttons mt-2">
           <CustomButton type="is-info" label="Select" @click="$emit('select', game.id)" />
           <CustomButton type="is-warning" label="Edit" @click="$emit('edit', game)" />
@@ -111,6 +112,7 @@ const createNew = () => {
       poolHeader: '',
       worstHeader: '',
       shareText: '',
+      active: false,
     };
     console.log('createNew called, emitting edit with new game:', newGame);
     emit('edit', newGame);

--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -43,6 +43,12 @@
         <input v-model="localGame.shareText" class="input" type="text" placeholder="e.g., Share your score!" />
       </div>
     </div>
+    <div class="field">
+      <label class="label has-text-white">Active</label>
+      <div class="control">
+        <input type="checkbox" v-model="localGame.active" />
+      </div>
+    </div>
     <div v-if="gameTypeCustom === 'PyramidConfig'">
       <h3 class="subtitle has-text-white">Pyramid Config</h3>
       <p class="has-text-grey-light">Rows are managed in the Rows tab.</p>
@@ -86,7 +92,7 @@ const emit = defineEmits<{
 }>();
 
 const userStore = useUserStore();
-const localGame = ref<Game>({ ...props.game });
+const localGame = ref<Game>({ active: false, ...props.game });
 const isSaving = ref(false);
 const error = ref<string | null>(null);
 const success = ref<string | null>(null);
@@ -175,6 +181,7 @@ const save = async () => {
       poolHeader: localGame.value.poolHeader || null,
       worstHeader: localGame.value.worstHeader || null,
       shareText: localGame.value.shareText || null,
+      active: localGame.value.active || false,
     };
     console.log('Saving game to Firestore:', { id: localGame.value.id, data: gameData });
     await setDoc(doc(db, 'games', localGame.value.id), gameData);

--- a/apps/client/src/views/Home.vue
+++ b/apps/client/src/views/Home.vue
@@ -53,6 +53,7 @@ interface Game {
   gameTypeId: string;
   image: string;
   isComingSoon: boolean;
+  active: boolean;
   route: string;
 }
 
@@ -60,8 +61,8 @@ const games = ref<Game[]>([]);
 
 onMounted(() => {
   console.log('Home: Fetching games from Firestore...');
-  const q = query(collection(db, 'games'));
-  onSnapshot(q, (snapshot) => {
+    const q = query(collection(db, 'games'));
+    onSnapshot(q, (snapshot) => {
     games.value = snapshot.docs.map((doc) => {
       const data = doc.data();
       console.log('Home: Game fetched:', { id: doc.id, data });
@@ -72,9 +73,10 @@ onMounted(() => {
         gameTypeId: data.gameTypeId || '',
         image: data.custom?.image || fallbackImg,
         isComingSoon: data.custom?.isComingSoon || false,
+        active: data.active ?? false,
         route: data.gameTypeId === 'PyramidTier' ? `/games/PyramidTier?game=${doc.id}` : `/games/${data.gameTypeId}`,
-      };
-    });
+      } as Game;
+    }).filter(g => g.active);
     console.log('Home: Games updated:', games.value);
   }, (err) => {
     console.error('Home: Error fetching games:', err.message, err);

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -14,6 +14,7 @@ export interface Game {
   name: string;
   description: string;
   gameTypeId: string;
+  active: boolean;
   gameHeader?: string;
   poolHeader?: string;
   worstHeader?: string;


### PR DESCRIPTION
## Summary
- add `active` field to Game model
- allow toggling active status in the admin
- list active status in admin game list
- filter client home games by active status

## Testing
- `pnpm build:shared` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_685953081b90832f89c544d2ab6e91f7