### PR TITLE
Add name field to PyramidItem

### DIFF
--- a/apps/admin/src/components/AdminAddItems.vue
+++ b/apps/admin/src/components/AdminAddItems.vue
@@ -5,6 +5,7 @@
     <form @submit.prevent="addItem">
       <input v-model="newItem.id" placeholder="ID" required />
       <input v-model="newItem.label" placeholder="Label" required />
+      <input v-model="newItem.name" placeholder="Name" required />
       <input v-model="newItem.image" placeholder="Image URL" required />
       <button type="submit">Add Item</button>
     </form>
@@ -17,7 +18,7 @@ import { arrayUnion, doc, updateDoc } from 'firebase/firestore';
 import { db } from '@top-x/shared';
 
 const gameId = 'Pyramid_Cities';
-const newItem = ref({ id: '', label: '', image: '' });
+const newItem = ref({ id: '', label: '', name: '', image: '' });
 
 async function addItem() {
   const gameDocRef = doc(db, 'games', gameId);
@@ -25,9 +26,10 @@ async function addItem() {
     'custom.items': arrayUnion({
       id: newItem.value.id,
       label: newItem.value.label,
+      name: newItem.value.name,
       src: newItem.value.image,
     }),
   });
-  newItem.value = { id: '', label: '', image: '' };
+  newItem.value = { id: '', label: '', name: '', image: '' };
 }
 </script>

--- a/apps/admin/src/components/PyramidItemList.vue
+++ b/apps/admin/src/components/PyramidItemList.vue
@@ -13,6 +13,7 @@
           </div>
           <div class="media-content">
             <p class="title is-6 has-text-white">{{ item.label }}</p>
+            <p class="subtitle is-7 has-text-grey-light">Name: {{ item.name }}</p>
             <p class="subtitle is-7 has-text-grey-light">ID: {{ item.id }}</p>
             <p v-if="item.color" class="has-text-grey-light">Color: {{ item.color }}</p>
           </div>
@@ -143,7 +144,7 @@ const createNew = () => {
     return;
   }
   console.log('createNew called, emitting edit with new item');
-  emit('edit', { id: '', src: '', label: '' });
+  emit('edit', { id: '', src: '', label: '', name: '' });
 };
 
 const refresh = () => {

--- a/apps/admin/src/components/PyramidItemRecord.vue
+++ b/apps/admin/src/components/PyramidItemRecord.vue
@@ -14,6 +14,12 @@
       </div>
     </div>
     <div class="field">
+      <label class="label has-text-white">Name</label>
+      <div class="control">
+        <input v-model="localItem.name" class="input" type="text" placeholder="e.g., city_name" />
+      </div>
+    </div>
+    <div class="field">
       <label class="label has-text-white">Image URL</label>
       <div class="control">
         <input v-model="localItem.src" class="input" type="text" placeholder="e.g., https://example.com/image.jpg" />
@@ -82,8 +88,8 @@ const save = async () => {
     console.log('save blocked: No gameId');
     return;
   }
-  if (!localItem.value.id || !localItem.value.label || !localItem.value.src) {
-    error.value = 'Item ID, Label, and Image URL are required';
+  if (!localItem.value.id || !localItem.value.name || !localItem.value.label || !localItem.value.src) {
+    error.value = 'Item ID, Name, Label, and Image URL are required';
     console.log('save blocked: Missing required fields', localItem.value);
     return;
   }

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -1,6 +1,7 @@
 export interface PyramidItem {
   id: string;
   label: string;
+  name: string;
   src: string;
   color?: string;
 }


### PR DESCRIPTION
## Summary
- add a `name` property to the `PyramidItem` type
- collect `name` information in AdminAddItems
- display and edit the new field in item list and record

## Testing
- `pnpm build:shared` *(fails: Cannot find type definition file for 'node')*
- `pnpm build:admin` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_685afcf2e2dc832fbee6b5ed3abb48dd