### PR TITLE
Add HideRowLabel to pyramid config

### DIFF
--- a/apps/admin/src/components/GameList.vue
+++ b/apps/admin/src/components/GameList.vue
@@ -107,7 +107,7 @@ const createNew = () => {
       name: '',
       description: '',
       gameTypeId: props.selectedGameTypeId,
-      custom: { items: [], rows: [], sortItems: { orderBy: 'id', order: 'asc' } }, // Default for PyramidConfig
+      custom: { items: [], rows: [], sortItems: { orderBy: 'id', order: 'asc' }, HideRowLabel: false }, // Default for PyramidConfig
       gameHeader: '',
       poolHeader: '',
       worstHeader: '',

--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -73,6 +73,12 @@
           </select>
         </div>
       </div>
+      <div class="field">
+        <label class="label has-text-white">Hide Row Labels</label>
+        <div class="control">
+          <input type="checkbox" v-model="(localGame.custom as PyramidConfig).HideRowLabel" />
+        </div>
+      </div>
     </div>
     <div v-if="gameTypeCustom === 'TriviaConfig'">
       <h3 class="subtitle has-text-white">Trivia Config</h3>
@@ -120,6 +126,13 @@ if (
   !(localGame.value.custom as any).sortItems
 ) {
   (localGame.value.custom as PyramidConfig).sortItems = { orderBy: 'id', order: 'asc' };
+}
+if (
+  'custom' in localGame.value &&
+  (localGame.value.custom as any) &&
+  (localGame.value.custom as any).HideRowLabel === undefined
+) {
+  (localGame.value.custom as PyramidConfig).HideRowLabel = false;
 }
 const isSaving = ref(false);
 const error = ref<string | null>(null);
@@ -188,6 +201,9 @@ const save = async () => {
       sortItems: 'sortItems' in (localGame.value.custom || {})
         ? (localGame.value.custom as PyramidConfig).sortItems
         : { orderBy: 'id', order: 'asc' },
+      HideRowLabel: 'HideRowLabel' in (localGame.value.custom || {})
+        ? (localGame.value.custom as PyramidConfig).HideRowLabel
+        : false,
     };
     console.log('PyramidConfig customData created:', customData);
   } else if (gameTypeCustom.value === 'TriviaConfig') {

--- a/apps/client/src/components/PyramidTable.vue
+++ b/apps/client/src/components/PyramidTable.vue
@@ -5,7 +5,7 @@
 
       <div class="pyramid">
         <div v-for="(row, rowIndex) in pyramid" :key="rowIndex" class="pyramid-row-container">
-          <div class="row-label has-text-white">
+          <div v-if="!props.hideRowLabel" class="row-label has-text-white">
             {{ rows[rowIndex]?.label || toRoman(rowIndex + 1) }}
           </div>
           <div class="pyramid-row">
@@ -98,6 +98,7 @@ const props = withDefaults(defineProps<{
   items: PyramidItem[];
   rows: PyramidRow[];
   sortItems: SortOption;
+  hideRowLabel?: boolean;
   gameHeader?: string;
   poolHeader?: string;
   worstHeader?: string;
@@ -108,6 +109,7 @@ const props = withDefaults(defineProps<{
   worstHeader: 'Worst Item',
   shareText: '',
   sortItems: () => ({ orderBy: 'id', order: 'asc' } as SortOption),
+  hideRowLabel: false,
 });
 
 const emit = defineEmits<{

--- a/apps/client/src/views/games/PyramidTier.vue
+++ b/apps/client/src/views/games/PyramidTier.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="pyramid-tier">
     <h1>{{ gameDescription }}</h1>
-    <PyramidTable :items="items" :rows="rows" :sort-items="sortItems" @submit="handleSubmit" />
+    <PyramidTable :items="items" :rows="rows" :sort-items="sortItems" :hide-row-label="hideRowLabel" @submit="handleSubmit" />
   </div>
 </template>
 
@@ -22,6 +22,7 @@ const gameDescription = ref('');
 const items = ref<PyramidItem[]>([]);
 const rows = ref<PyramidRow[]>([]);
 const sortItems = ref<SortOption>({ orderBy: 'id', order: 'asc' });
+const hideRowLabel = ref(false);
 
 onMounted(async () => {
   console.log('PyramidTier: onMounted called with gameId:', gameId);
@@ -39,6 +40,7 @@ onMounted(async () => {
       items.value = gameData.custom?.items || [];
       rows.value = gameData.custom?.rows || [] as PyramidRow[];
       sortItems.value = gameData.custom?.sortItems || { orderBy: 'id', order: 'asc' };
+      hideRowLabel.value = gameData.custom?.HideRowLabel ?? false;
       console.log('PyramidTier: Game data fetched:', gameData);
       console.log('Pyramid: Items and rows assigned:', { items: items.value, rows: rows.value });
     } else {

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -14,6 +14,7 @@ export interface PyramidConfig {
   items: PyramidItem[];
   rows: PyramidRow[];
   sortItems: SortOption;
+  HideRowLabel: boolean;
 }
 export interface PyramidRow {
   id: number;


### PR DESCRIPTION
## Summary
- support hiding row labels in `PyramidConfig`
- expose new option in admin when editing/creating games
- default the flag when creating a new game
- pass config to client game view and hide labels if enabled

## Testing
- `pnpm build:shared` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_b_685bdc91dddc832fb8068046fbce3364