### PR TITLE
Move pyramid headers to config

### DIFF
--- a/apps/admin/src/components/GameList.vue
+++ b/apps/admin/src/components/GameList.vue
@@ -107,10 +107,16 @@ const createNew = () => {
       name: '',
       description: '',
       gameTypeId: props.selectedGameTypeId,
-      custom: { items: [], rows: [], sortItems: { orderBy: 'id', order: 'asc' }, HideRowLabel: false }, // Default for PyramidConfig
+      custom: {
+        items: [],
+        rows: [],
+        sortItems: { orderBy: 'id', order: 'asc' },
+        HideRowLabel: false,
+        poolHeader: '',
+        worstHeader: '',
+        worstPoints: 0
+      }, // Default for PyramidConfig
       gameHeader: '',
-      poolHeader: '',
-      worstHeader: '',
       shareText: '',
       active: false,
     };

--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -26,18 +26,6 @@
       </div>
     </div>
     <div class="field">
-      <label class="label has-text-white">Pool Header (Optional)</label>
-      <div class="control">
-        <input v-model="localGame.poolHeader" class="input" type="text" placeholder="e.g., Question Pool" />
-      </div>
-    </div>
-    <div class="field">
-      <label class="label has-text-white">Word Header (Optional)</label>
-      <div class="control">
-        <input v-model="localGame.worstHeader" class="input" type="text" placeholder="e.g., Key Terms" />
-      </div>
-    </div>
-    <div class="field">
       <label class="label has-text-white">Share Text (Optional)</label>
       <div class="control">
         <input v-model="localGame.shareText" class="input" type="text" placeholder="e.g., Share your score!" />
@@ -77,6 +65,24 @@
         <label class="label has-text-white">Hide Row Labels</label>
         <div class="control">
           <input type="checkbox" v-model="(localGame.custom as PyramidConfig).HideRowLabel" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Pool Header (Optional)</label>
+        <div class="control">
+          <input v-model="(localGame.custom as PyramidConfig).poolHeader" class="input" type="text" placeholder="e.g., Question Pool" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Worst Header (Optional)</label>
+        <div class="control">
+          <input v-model="(localGame.custom as PyramidConfig).worstHeader" class="input" type="text" placeholder="e.g., Key Terms" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Worst Points</label>
+        <div class="control">
+          <input v-model.number="(localGame.custom as PyramidConfig).worstPoints" class="input" type="number" />
         </div>
       </div>
     </div>
@@ -133,6 +139,27 @@ if (
   (localGame.value.custom as any).HideRowLabel === undefined
 ) {
   (localGame.value.custom as PyramidConfig).HideRowLabel = false;
+}
+if (
+  'custom' in localGame.value &&
+  (localGame.value.custom as any) &&
+  (localGame.value.custom as any).poolHeader === undefined
+) {
+  (localGame.value.custom as PyramidConfig).poolHeader = '';
+}
+if (
+  'custom' in localGame.value &&
+  (localGame.value.custom as any) &&
+  (localGame.value.custom as any).worstHeader === undefined
+) {
+  (localGame.value.custom as PyramidConfig).worstHeader = '';
+}
+if (
+  'custom' in localGame.value &&
+  (localGame.value.custom as any) &&
+  (localGame.value.custom as any).worstPoints === undefined
+) {
+  (localGame.value.custom as PyramidConfig).worstPoints = 0;
 }
 const isSaving = ref(false);
 const error = ref<string | null>(null);
@@ -204,6 +231,15 @@ const save = async () => {
       HideRowLabel: 'HideRowLabel' in (localGame.value.custom || {})
         ? (localGame.value.custom as PyramidConfig).HideRowLabel
         : false,
+      poolHeader: 'poolHeader' in (localGame.value.custom || {})
+        ? (localGame.value.custom as PyramidConfig).poolHeader
+        : undefined,
+      worstHeader: 'worstHeader' in (localGame.value.custom || {})
+        ? (localGame.value.custom as PyramidConfig).worstHeader
+        : undefined,
+      worstPoints: 'worstPoints' in (localGame.value.custom || {})
+        ? (localGame.value.custom as PyramidConfig).worstPoints
+        : undefined,
     };
     console.log('PyramidConfig customData created:', customData);
   } else if (gameTypeCustom.value === 'TriviaConfig') {
@@ -225,8 +261,6 @@ const save = async () => {
       gameTypeId: props.gameTypeId,
       custom: customData,
       gameHeader: localGame.value.gameHeader || null,
-      poolHeader: localGame.value.poolHeader || null,
-      worstHeader: localGame.value.worstHeader || null,
       shareText: localGame.value.shareText || null,
       active: localGame.value.active || false,
     };

--- a/apps/client/src/components/PyramidTable.vue
+++ b/apps/client/src/components/PyramidTable.vue
@@ -95,8 +95,8 @@ const props = defineProps<{
   sortItems: SortOption;
   hideRowLabel: boolean;
   gameHeader: string;
-  poolHeader: string;
-  worstHeader: string;
+  poolHeader?: string;
+  worstHeader?: string;
   shareText?: string;
 }>();
 

--- a/apps/client/src/views/games/PyramidTier.vue
+++ b/apps/client/src/views/games/PyramidTier.vue
@@ -37,6 +37,7 @@ const gameHeader = ref('Your Pyramid');
 const poolHeader = ref('Item Pool');
 const worstHeader = ref('Worst Item');
 const shareText = ref('');
+const worstPoints = ref(0);
 
 onMounted(async () => {
   console.log('PyramidTier: onMounted called with gameId:', gameId);
@@ -57,13 +58,14 @@ onMounted(async () => {
 
       gameDescription.value = gameData.description || '';
       gameHeader.value = gameData.gameHeader || 'Your Pyramid';
-      poolHeader.value = gameData.poolHeader || 'Item Pool';
-      worstHeader.value = gameData.worstHeader || 'Worst Item';
+      poolHeader.value = gameData.custom?.poolHeader || 'Item Pool';
+      worstHeader.value = gameData.custom?.worstHeader || 'Worst Item';
       shareText.value = gameData.shareText || '';
       items.value = gameData.custom?.items || [];
       rows.value = gameData.custom?.rows || [];
       sortItems.value = gameData.custom?.sortItems || { orderBy: 'id', order: 'asc' };
       hideRowLabel.value = gameData.custom?.HideRowLabel ?? false;
+      worstPoints.value = gameData.custom?.worstPoints ?? 0;
 
       console.log('PyramidTier: Game data fetched:', {
         gameDescription: gameDescription.value,
@@ -192,7 +194,7 @@ function calculateScore(pyramid: PyramidSlot[][], worstItem: PyramidItem | null)
     });
   });
   if (worstItem) {
-    score += 0; // Adjust as needed
+    score += worstPoints.value;
   }
   console.log('PyramidTier: Calculated score:', score);
   return score;

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -16,8 +16,6 @@ export interface Game {
   gameTypeId: string;
   active: boolean;
   gameHeader?: string;
-  poolHeader?: string;
-  worstHeader?: string;
   shareText?: string;
   custom: PyramidConfig | TriviaConfig; // Union of possible config types
 }

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -3,6 +3,7 @@ export interface PyramidItem {
   label: string;
   name: string;
   src: string;
+  description?: string;
   color?: string;
 }
 
@@ -15,6 +16,9 @@ export interface PyramidConfig {
   rows: PyramidRow[];
   sortItems: SortOption;
   HideRowLabel: boolean;
+  poolHeader?: string;
+  worstHeader?: string;
+  worstPoints?: number;
 }
 export interface PyramidRow {
   id: number;


### PR DESCRIPTION
## Summary
- move `poolHeader` and `worstHeader` from `Game` to `PyramidConfig`
- add `worstPoints` to pyramid config
- add optional description on `PyramidItem`
- update admin UIs to edit new fields
- adjust PyramidTable and PyramidTier for new config

## Testing
- `pnpm --filter ./packages/shared build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_6860565cc9b0832fa581304324d66869