### PR TITLE
Add GA and Adsense

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -14,6 +14,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TOP-X</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%VITE_GOOGLE_ADS_CLIENT_ID%" crossorigin="anonymous"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/client/src/components/PyramidTable.vue
+++ b/apps/client/src/components/PyramidTable.vue
@@ -93,6 +93,15 @@
           <font-awesome-icon :icon="['fas', 'circle-info']" class="info-icon" @click.stop="showDescription(image)" />
         </div>
       </div>
+      <ins class="adsbygoogle"
+        style="display:block"
+        data-ad-client="%VITE_GOOGLE_ADS_CLIENT_ID%"
+        data-ad-slot="%VITE_GOOGLE_ADS_SLOT_ID%"
+        data-ad-format="auto"
+        data-full-width-responsive="true"></ins>
+      <script>
+        (adsbygoogle = window.adsbygoogle || []).push({});
+      </script>
 
       <!-- Description Tab -->
       <div v-show="showTab" :class="['description-tab', { show: showTab }]">

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -13,6 +13,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 library.add(faXTwitter, faSave, faUserPlus, faRedo, faPlay, faSearch, faTable,faMedal, faSortUp, faSortDown,faCircleInfo);
 
 import 'bulma/css/bulma.min.css';
+import { logEvent } from 'firebase/analytics';
+import { analytics } from '@top-x/shared';
 
 
 const pinia = createPinia();
@@ -23,3 +25,12 @@ createApp(App)
   .use(pinia)
   .component('font-awesome-icon', FontAwesomeIcon)
   .mount('#app');
+
+window.addEventListener('click', (e) => {
+  const target = e.target as HTMLElement;
+  const name = target.getAttribute('data-analytics-name') || target.tagName;
+  logEvent(analytics, 'click', {
+    element: name,
+    page_path: window.location.pathname,
+  });
+});

--- a/apps/client/src/router/index.ts
+++ b/apps/client/src/router/index.ts
@@ -13,6 +13,8 @@ import PyramidResultLoggedOut from '@/components/PyramidResultLoggedOut.vue';
 import RivalSearch from '@/views/RivalSearch.vue';
 
 import { useUserStore } from '../stores/user';
+import { logEvent } from 'firebase/analytics';
+import { analytics } from '@top-x/shared';
 
 const routes = [
   { path: '/', name: 'Home', component: Home },
@@ -66,6 +68,13 @@ router.beforeEach((to, from, next) => {
   } else {
     next();
   }
+});
+
+router.afterEach((to) => {
+  logEvent(analytics, 'page_view', {
+    page_path: to.fullPath,
+    page_title: String(to.name || to.fullPath),
+  });
 });
 
 export default router;

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -22,8 +22,11 @@ export default defineConfig({
     'import.meta.env.VITE_FIREBASE_STORAGE_BUCKET': JSON.stringify(process.env.VITE_FIREBASE_STORAGE_BUCKET),
     'import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID': JSON.stringify(process.env.VITE_FIREBASE_MESSAGING_SENDER_ID),
     'import.meta.env.VITE_FIREBASE_APP_ID': JSON.stringify(process.env.VITE_FIREBASE_APP_ID),
+    'import.meta.env.VITE_FIREBASE_MEASUREMENT_ID': JSON.stringify(process.env.VITE_FIREBASE_MEASUREMENT_ID),
+    'import.meta.env.VITE_GOOGLE_ADS_CLIENT_ID': JSON.stringify(process.env.VITE_GOOGLE_ADS_CLIENT_ID),
+    'import.meta.env.VITE_GOOGLE_ADS_SLOT_ID': JSON.stringify(process.env.VITE_GOOGLE_ADS_SLOT_ID),
   },
   optimizeDeps: {
-    include: ['firebase/app', 'firebase/auth', 'firebase/firestore', 'firebase/functions'],
+    include: ['firebase/app', 'firebase/auth', 'firebase/firestore', 'firebase/functions', 'firebase/analytics'],
   },
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ import { initializeApp } from 'firebase/app';
 import { getAuth, setPersistence, browserLocalPersistence } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getFunctions } from 'firebase/functions';
+import { getAnalytics } from 'firebase/analytics';
 
 const detectedHost = window.location.hostname;
 
@@ -15,11 +16,13 @@ const firebaseConfig = {
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
 const app = initializeApp(firebaseConfig);
 
 const auth = getAuth(app);
+const analytics = getAnalytics(app);
 
 setPersistence(auth, browserLocalPersistence)
   .then(() => console.log('Auth persistence set to local'))
@@ -28,4 +31,4 @@ setPersistence(auth, browserLocalPersistence)
 const db = getFirestore(app);
 const functions = getFunctions(app);
 
-export { app, auth, db, functions };
+export { app, auth, db, functions, analytics };

--- a/packages/shared/vite-env.d.ts
+++ b/packages/shared/vite-env.d.ts
@@ -8,6 +8,9 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_STORAGE_BUCKET: string;
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
   readonly VITE_FIREBASE_APP_ID: string;
+  readonly VITE_FIREBASE_MEASUREMENT_ID: string;
+  readonly VITE_GOOGLE_ADS_CLIENT_ID?: string;
+  readonly VITE_GOOGLE_ADS_SLOT_ID?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- include Firebase measurement ID and analytics init in shared package
- add GA page and click tracking on the client
- add Google AdSense support
- show ad below the pyramid item pool

## Testing
- `pnpm build:client` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860e9129f98832fa34baa0839a4dccc