### PR TITLE
Remove light mode

### DIFF
--- a/apps/admin/src/style.css
+++ b/apps/admin/src/style.css
@@ -3,7 +3,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
+  color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 
@@ -65,15 +65,3 @@ button:focus-visible {
   text-align: center;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -4,11 +4,8 @@
     <meta charset="UTF-8" />
     <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
      <!-- <link rel="icon" href="/favicon.ico" type="image/x-icon"> -->
-     <!-- Favicon for light mode (white background) -->
-    <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)" type="image/svg+xml">
-
-    <!-- Favicon for dark mode (black background) -->
-    <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)" type="image/svg+xml">
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon-dark.svg" type="image/svg+xml">
 
     
 


### PR DESCRIPTION
## Summary
- remove light theme favicon reference
- use dark mode only in admin styles

## Testing
- `grep -n "prefers-color-scheme" -n apps/admin/src/style.css`


------
https://chatgpt.com/codex/tasks/task_b_6860ffb1b46c832f904aa61cb3b2abc1