### PR TITLE
Fix PyramidMyVote login flow

### DIFF
--- a/apps/client/src/components/PyramidMyVote.vue
+++ b/apps/client/src/components/PyramidMyVote.vue
@@ -63,6 +63,7 @@ watch(
       if (savedPyramid) {
         const cachedVote = JSON.parse(savedPyramid);
         await saveCachedVote(cachedVote, newUser.uid);
+        localStorage.removeItem(`pyramid_${props.gameId}`);
         console.log('PyramidMyVote: Cached vote saved to user database');
       }
     }
@@ -74,6 +75,15 @@ async function loginWithX() {
     const success = await userStore.loginWithX();
     if (success) {
       console.log('PyramidMyVote: Login successful');
+      if (props.gameId) {
+        const savedPyramid = localStorage.getItem(`pyramid_${props.gameId}`);
+        if (savedPyramid && userStore.user) {
+          const cachedVote = JSON.parse(savedPyramid);
+          await saveCachedVote(cachedVote, userStore.user.uid);
+          localStorage.removeItem(`pyramid_${props.gameId}`);
+          console.log('PyramidMyVote: Cached vote saved after login');
+        }
+      }
     }
   } catch (err: any) {
     console.error('PyramidMyVote: Login error:', err.message);


### PR DESCRIPTION
## Summary
- ensure cached pyramid is removed and saved after login
- save cached vote directly from `loginWithX`

## Testing
- `pnpm build:client` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68628c4eb2c8832fbab225bc04b46454