### PR TITLE
Add SEO tags to client pages

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -30,7 +30,8 @@
     "vue-draggable-plus": "^0.6.0",
     "vue-router": "^4.5.0",
     "vuedraggable": "^4.1.0",
-    "vuefire": "^3.2.1"
+    "vuefire": "^3.2.1",
+    "@vueuse/head": "^1.2.1"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.16",

--- a/apps/client/src/components/PyramidResultLoggedIn.vue
+++ b/apps/client/src/components/PyramidResultLoggedIn.vue
@@ -173,6 +173,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, nextTick, computed } from 'vue';
+import { useHead } from '@vueuse/head';
 import { useRoute, useRouter } from 'vue-router';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '@top-x/shared';
@@ -191,6 +192,13 @@ const props = defineProps<{
   rows: PyramidRow[];
   gameTitle?: string;
 }>();
+
+useHead({
+  title: 'Your Pyramid Results - TOP-X',
+  meta: [
+    { name: 'description', content: 'View your ranked pyramid results and stats on TOP-X.' },
+  ],
+});
 
 const route = useRoute();
 const router = useRouter();

--- a/apps/client/src/components/PyramidResultLoggedOut.vue
+++ b/apps/client/src/components/PyramidResultLoggedOut.vue
@@ -13,8 +13,16 @@
 import Card from '@top-x/shared/components/Card.vue';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
 import { useUserStore } from '@/stores/user';
+import { useHead } from '@vueuse/head';
 
 const userStore = useUserStore();
+
+useHead({
+  title: 'Pyramid Result - TOP-X',
+  meta: [
+    { name: 'description', content: 'Log in to save your pyramid results on TOP-X.' },
+  ],
+});
 
 function login() {
   userStore.loginWithX();

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,5 +1,6 @@
 // Entry point for the client application
 import { createApp } from 'vue';
+import { createHead } from '@vueuse/head';
 import App from './App.vue';
 import router from './router';
 import { createPinia } from 'pinia';
@@ -20,9 +21,12 @@ import { analytics } from '@top-x/shared';
 const pinia = createPinia();
 pinia.use(piniaPluginPersistedstate);
 
+const head = createHead();
+
 createApp(App)
   .use(router)
   .use(pinia)
+  .use(head)
   .component('font-awesome-icon', FontAwesomeIcon)
   .mount('#app');
 

--- a/apps/client/src/views/About.vue
+++ b/apps/client/src/views/About.vue
@@ -36,12 +36,21 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { useHead } from '@vueuse/head';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
 
 export default defineComponent({
   name: 'AboutPage',
   components: {
     CustomButton,
+  },
+  setup() {
+    useHead({
+      title: 'About TOP-X',
+      meta: [
+        { name: 'description', content: 'Learn about TOP-X and how Grok powers our gaming platform.' },
+      ],
+    });
   },
 });
 </script>

--- a/apps/client/src/views/FAQ.vue
+++ b/apps/client/src/views/FAQ.vue
@@ -31,12 +31,21 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { useHead } from '@vueuse/head';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
 
 export default defineComponent({
   name: 'FAQPage',
   components: {
     CustomButton,
+  },
+  setup() {
+    useHead({
+      title: 'TOP-X FAQ',
+      meta: [
+        { name: 'description', content: 'Frequently asked questions about TOP-X login, privacy, and gameplay.' },
+      ],
+    });
   },
   data() {
     return {

--- a/apps/client/src/views/FrenemySearch.vue
+++ b/apps/client/src/views/FrenemySearch.vue
@@ -44,6 +44,7 @@
 <script setup lang="ts">
 import { useUserStore } from '@/stores/user';
 import { ref, watch } from 'vue';
+import { useHead } from '@vueuse/head';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 import { db } from '@top-x/shared';
 import { debounce } from 'lodash';
@@ -53,6 +54,13 @@ import CustomButton from '@top-x/shared/components/CustomButton.vue';
 import type { UserProfile } from '@top-x/shared';
 
 const userStore = useUserStore();
+
+useHead({
+  title: 'Find Frenemies - TOP-X',
+  meta: [
+    { name: 'description', content: 'Search for friends or rivals and add frenemies on TOP-X.' },
+  ],
+});
 const searchQuery = ref('');
 const searchResults = ref<UserProfile[]>([]);
 const isLoading = ref(false);

--- a/apps/client/src/views/Home.vue
+++ b/apps/client/src/views/Home.vue
@@ -40,6 +40,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
+import { useHead } from '@vueuse/head';
 import { collection, query, onSnapshot } from 'firebase/firestore';
 import { db } from '@top-x/shared';
 import Card from '@top-x/shared/components/Card.vue';
@@ -58,6 +59,16 @@ interface Game {
 }
 
 const games = ref<Game[]>([]);
+
+useHead({
+  title: 'TOP-X Games',
+  meta: [
+    {
+      name: 'description',
+      content: 'Play fun social games and compete with friends on TOP-X.',
+    },
+  ],
+});
 
 onMounted(() => {
   console.log('Home: Fetching games from Firestore...');

--- a/apps/client/src/views/Profile.vue
+++ b/apps/client/src/views/Profile.vue
@@ -60,6 +60,7 @@
 <script setup lang="ts">
 import { useUserStore } from '@/stores/user';
 import { computed, ref, onMounted } from 'vue';
+import { useHead } from '@vueuse/head';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '@top-x/shared';
 
@@ -77,6 +78,13 @@ interface LeaderboardEntry {
 }
 
 const userStore = useUserStore();
+
+useHead({
+  title: 'Your Profile - TOP-X',
+  meta: [
+    { name: 'description', content: 'View your TOP-X profile, stats and frenemies.' },
+  ],
+});
 
 const displayName = computed(() => userStore.profile?.displayName || 'Anonymous');
 const username = computed(() => userStore.profile?.username ? `@${userStore.profile.username}` : '@Anonymous');

--- a/apps/client/src/views/games/PyramidTier.vue
+++ b/apps/client/src/views/games/PyramidTier.vue
@@ -32,6 +32,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
+import { useHead } from '@vueuse/head';
 import { useRoute, useRouter } from 'vue-router';
 import { doc, getDoc, setDoc, runTransaction } from 'firebase/firestore';
 import { db } from '@top-x/shared';
@@ -43,6 +44,13 @@ import { PyramidItem, PyramidRow, PyramidSlot, PyramidData, SortOption } from '@
 const route = useRoute();
 const router = useRouter();
 const userStore = useUserStore();
+
+useHead({
+  title: 'Pyramid Tier Game - TOP-X',
+  meta: [
+    { name: 'description', content: 'Rank items and build your pyramid in the TOP-X Pyramid Tier game.' },
+  ],
+});
 const gameId = ref(route.query.game as string);
 const gameDescription = ref('');
 const items = ref<PyramidItem[]>([]);

--- a/apps/client/src/views/games/Trivia.vue
+++ b/apps/client/src/views/games/Trivia.vue
@@ -76,6 +76,7 @@
 import { useTriviaStore } from '@/stores/trivia';
 import { useUserStore } from '@/stores/user';
 import { computed, watch, ref, onMounted } from 'vue';
+import { useHead } from '@vueuse/head';
 import { useRoute } from 'vue-router';
 import StartTrivia from '@/components/StartTrivia.vue';
 import TriviaGame from '@/components/TriviaGame.vue';
@@ -86,6 +87,13 @@ import { getPercentileRank } from '@/services/trivia';
 const triviaStore = useTriviaStore();
 const userStore = useUserStore();
 const route = useRoute();
+
+useHead({
+  title: 'Trivia Game - TOP-X',
+  meta: [
+    { name: 'description', content: 'Challenge yourself and your friends in the TOP-X Trivia game.' },
+  ],
+});
 
 const gameId = 'smartest_on_x';
 


### PR DESCRIPTION
## Summary
- add @vueuse/head to the client app
- configure head in main.ts
- set title and description for every route

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@vueuse%2Fhead)*
- `pnpm --filter ./apps/client build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862f45ce288832f83b41f8d64a6bcf5