### PR TITLE
Add image and share image title fields

### DIFF
--- a/apps/admin/src/components/GameList.vue
+++ b/apps/admin/src/components/GameList.vue
@@ -102,24 +102,26 @@ const deleteGame = async (id: string) => {
 
 const createNew = () => {
   if (props.selectedGameTypeId) {
-    const newGame: Game = {
-      id: '',
-      name: '',
-      description: '',
-      gameTypeId: props.selectedGameTypeId,
-      custom: {
-        items: [],
-        rows: [],
-        sortItems: { orderBy: 'id', order: 'asc' },
-        HideRowLabel: false,
-        poolHeader: '',
-        worstHeader: '',
-        worstPoints: 0
-      }, // Default for PyramidConfig
-      gameHeader: '',
-      shareText: '',
-      active: false,
-    };
+      const newGame: Game = {
+        id: '',
+        name: '',
+        description: '',
+        gameTypeId: props.selectedGameTypeId,
+        custom: {
+          items: [],
+          rows: [],
+          sortItems: { orderBy: 'id', order: 'asc' },
+          HideRowLabel: false,
+          shareImageTitle: '',
+          poolHeader: '',
+          worstHeader: '',
+          worstPoints: 0
+        }, // Default for PyramidConfig
+        gameHeader: '',
+        shareText: '',
+        image: '',
+        active: false,
+      };
     console.log('createNew called, emitting edit with new game:', newGame);
     emit('edit', newGame);
   } else {

--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -32,6 +32,12 @@
       </div>
     </div>
     <div class="field">
+      <label class="label has-text-white">Image URL</label>
+      <div class="control">
+        <input v-model="localGame.image" class="input" type="text" placeholder="https://example.com/image.png" />
+      </div>
+    </div>
+    <div class="field">
       <label class="label has-text-white">Active</label>
       <div class="control">
         <input type="checkbox" v-model="localGame.active" />
@@ -61,17 +67,23 @@
           </select>
         </div>
       </div>
-      <div class="field">
-        <label class="label has-text-white">Hide Row Labels</label>
-        <div class="control">
-          <input type="checkbox" v-model="(localGame.custom as PyramidConfig).HideRowLabel" />
+        <div class="field">
+          <label class="label has-text-white">Hide Row Labels</label>
+          <div class="control">
+            <input type="checkbox" v-model="(localGame.custom as PyramidConfig).HideRowLabel" />
+          </div>
         </div>
-      </div>
-      <div class="field">
-        <label class="label has-text-white">Pool Header (Optional)</label>
-        <div class="control">
-          <input v-model="(localGame.custom as PyramidConfig).poolHeader" class="input" type="text" placeholder="e.g., Question Pool" />
+        <div class="field">
+          <label class="label has-text-white">Share Image Title (Optional)</label>
+          <div class="control">
+            <input v-model="(localGame.custom as PyramidConfig).shareImageTitle" class="input" type="text" placeholder="Title shown on shared image" />
+          </div>
         </div>
+        <div class="field">
+          <label class="label has-text-white">Pool Header (Optional)</label>
+          <div class="control">
+            <input v-model="(localGame.custom as PyramidConfig).poolHeader" class="input" type="text" placeholder="e.g., Question Pool" />
+          </div>
       </div>
       <div class="field">
         <label class="label has-text-white">Worst Header (Optional)</label>
@@ -125,7 +137,7 @@ const emit = defineEmits<{
 }>();
 
 const userStore = useUserStore();
-const localGame = ref<Game>({ active: false, ...props.game });
+const localGame = ref<Game>({ image: '', active: false, ...props.game });
 if (
   'custom' in localGame.value &&
   (localGame.value.custom as any) &&
@@ -133,18 +145,25 @@ if (
 ) {
   (localGame.value.custom as PyramidConfig).sortItems = { orderBy: 'id', order: 'asc' };
 }
-if (
-  'custom' in localGame.value &&
-  (localGame.value.custom as any) &&
-  (localGame.value.custom as any).HideRowLabel === undefined
-) {
-  (localGame.value.custom as PyramidConfig).HideRowLabel = false;
-}
-if (
-  'custom' in localGame.value &&
-  (localGame.value.custom as any) &&
-  (localGame.value.custom as any).poolHeader === undefined
-) {
+  if (
+    'custom' in localGame.value &&
+    (localGame.value.custom as any) &&
+    (localGame.value.custom as any).HideRowLabel === undefined
+  ) {
+    (localGame.value.custom as PyramidConfig).HideRowLabel = false;
+  }
+  if (
+    'custom' in localGame.value &&
+    (localGame.value.custom as any) &&
+    (localGame.value.custom as any).shareImageTitle === undefined
+  ) {
+    (localGame.value.custom as PyramidConfig).shareImageTitle = '';
+  }
+  if (
+    'custom' in localGame.value &&
+    (localGame.value.custom as any) &&
+    (localGame.value.custom as any).poolHeader === undefined
+  ) {
   (localGame.value.custom as PyramidConfig).poolHeader = '';
 }
 if (
@@ -231,6 +250,9 @@ const save = async () => {
       HideRowLabel: 'HideRowLabel' in (localGame.value.custom || {})
         ? (localGame.value.custom as PyramidConfig).HideRowLabel
         : false,
+      shareImageTitle: 'shareImageTitle' in (localGame.value.custom || {})
+        ? (localGame.value.custom as PyramidConfig).shareImageTitle
+        : undefined,
       poolHeader: 'poolHeader' in (localGame.value.custom || {})
         ? (localGame.value.custom as PyramidConfig).poolHeader
         : undefined,
@@ -262,6 +284,7 @@ const save = async () => {
       custom: customData,
       gameHeader: localGame.value.gameHeader || null,
       shareText: localGame.value.shareText || null,
+      image: localGame.value.image || '',
       active: localGame.value.active || false,
     };
     console.log('Saving game to Firestore:', { id: localGame.value.id, data: gameData });

--- a/apps/client/src/views/Home.vue
+++ b/apps/client/src/views/Home.vue
@@ -82,7 +82,7 @@ onMounted(() => {
         name: data.name || 'Unnamed Game',
         description: data.description || 'No description available',
         gameTypeId: data.gameTypeId || '',
-        image: data.custom?.image || fallbackImg,
+        image: data.image || fallbackImg,
         isComingSoon: data.custom?.isComingSoon || false,
         active: data.active ?? false,
         route: data.gameTypeId === 'PyramidTier' ? `/games/PyramidTier?game=${doc.id}` : `/games/${data.gameTypeId}`,

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -17,6 +17,7 @@ export interface Game {
   active: boolean;
   gameHeader?: string;
   shareText?: string;
+  image: string;
   custom: PyramidConfig | TriviaConfig; // Union of possible config types
 }
 

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -16,6 +16,7 @@ export interface PyramidConfig {
   rows: PyramidRow[];
   sortItems: SortOption;
   HideRowLabel: boolean;
+  shareImageTitle?: string;
   poolHeader?: string;
   worstHeader?: string;
   worstPoints?: number;


### PR DESCRIPTION
## Summary
- extend `Game` type with `image`
- extend `PyramidConfig` with optional `shareImageTitle`
- handle new fields in admin UI
- display game images from new field in client

## Testing
- `pnpm build:shared` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_6866372e2654832fb426060fbd68f632