### PR TITLE
Expose Pyramid share image title

### DIFF
--- a/apps/client/src/components/PyramidMyVote.vue
+++ b/apps/client/src/components/PyramidMyVote.vue
@@ -8,6 +8,7 @@
       :game-header="gameHeader"
       :worst-header="worstHeader"
       :game-title="gameTitle"
+      :share-image-title="shareImageTitle"
       :hide-row-label="hideRowLabel"
       :user-profile="{ photoURL: userStore.user?.photoURL || '' }"
     />
@@ -52,6 +53,7 @@ const props = defineProps<{
   gameTitle?: string;
   hideRowLabel?: boolean;
   worstPoints?: number;
+  shareImageTitle?: string;
 }>();
 
 watch(

--- a/apps/client/src/components/PyramidNav.vue
+++ b/apps/client/src/components/PyramidNav.vue
@@ -22,6 +22,7 @@
         :game-header="gameHeader"
         :worst-header="worstHeader"
         :game-title="gameTitle"
+        :share-image-title="shareImageTitle"
         :hide-row-label="hideRowLabel"
         :game-id="gameId"
       />
@@ -69,6 +70,7 @@ const props = defineProps<{
   gameTitle?: string;
   hideRowLabel?: boolean;
   worstPoints?: number;
+  shareImageTitle?: string;
 }>();
 
 const activeTab = ref<'my-vote' | 'stats' | 'results'>('my-vote');

--- a/apps/client/src/components/PyramidView.vue
+++ b/apps/client/src/components/PyramidView.vue
@@ -22,7 +22,12 @@
       </div>
       <!-- Game Header -->
       <h2 class="subtitle has-text-success game-header" v-html="props.gameHeader"></h2>
-      <h2 class="has-text-white" style="margin-bottom: 1rem;text-align:center">Favorite U.S. presidents <br/> from top to bottom</h2>
+      <h2
+        v-if="props.shareImageTitle"
+        class="has-text-white"
+        style="margin-bottom: 1rem;text-align:center"
+        v-html="props.shareImageTitle"
+      ></h2>
 
       <!-- Pyramid -->
       <div class="pyramid">
@@ -97,6 +102,7 @@ const props = defineProps<{
   gameTitle?: string;
   hideRowLabel?: boolean;
   userProfile?: { photoURL: string };
+  shareImageTitle?: string;
 }>();
 
 const userStore = useUserStore();
@@ -267,7 +273,14 @@ async function downloadPyramid() {
     console.log('PyramidView: Canvas generated, size:', canvas.width, 'x', canvas.height);
     const link = document.createElement('a');
     link.href = canvas.toDataURL('image/png');
-    link.download = `${(props.gameHeader || props.gameTitle || 'your-pyramid').toLowerCase().replace(/\s+/g, '-')}.png`;
+    link.download = `${(
+      props.shareImageTitle ||
+      props.gameHeader ||
+      props.gameTitle ||
+      'your-pyramid'
+    )
+      .toLowerCase()
+      .replace(/\s+/g, '-')}.png`;
     link.click();
     console.log('PyramidView: Image download triggered');
   } catch (err: any) {

--- a/apps/client/src/views/games/PyramidTier.vue
+++ b/apps/client/src/views/games/PyramidTier.vue
@@ -24,6 +24,7 @@
       :game-header="gameHeader"
       :worst-header="worstHeader"
       :game-title="gameDescription"
+      :share-image-title="shareImageTitle"
       :hide-row-label="hideRowLabel"
       :worst-points="worstPoints"
     />
@@ -62,6 +63,7 @@ const poolHeader = ref('Item Pool');
 const worstHeader = ref('Worst Item');
 const shareText = ref('');
 const worstPoints = ref(0);
+const shareImageTitle = ref('');
 const hasSubmitted = ref(false);
 const pyramid = ref<PyramidSlot[][]>([
   [{ image: null }],
@@ -92,6 +94,7 @@ onMounted(async () => {
       poolHeader.value = gameData.custom?.poolHeader || 'Item Pool';
       worstHeader.value = gameData.custom?.worstHeader || 'Worst Item';
       shareText.value = gameData.custom?.shareText || '';
+      shareImageTitle.value = gameData.custom?.shareImageTitle || '';
       items.value = gameData.custom?.items || [];
       rows.value = gameData.custom?.rows || [];
       sortItems.value = gameData.custom?.sortItems || { orderBy: 'id', order: 'asc' };
@@ -104,6 +107,7 @@ onMounted(async () => {
         poolHeader: poolHeader.value,
         worstHeader: worstHeader.value,
         shareText: shareText.value,
+        shareImageTitle: shareImageTitle.value,
         items: items.value,
         rows: rows.value,
         sortItems: sortItems.value,


### PR DESCRIPTION
## Summary
- load PyramidConfig.shareImageTitle in PyramidTier view
- pass shareImageTitle through PyramidNav and PyramidMyVote
- display and use shareImageTitle in PyramidView when generating download image

## Testing
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_68664386ae0c832f8544282f1d9b2f6d