### PR TITLE
Fix PyramidNav losing game ID on tab navigation

### DIFF
--- a/apps/client/src/components/PyramidNav.vue
+++ b/apps/client/src/components/PyramidNav.vue
@@ -90,7 +90,12 @@ onMounted(() => {
 
 function setActiveTab(tab: 'my-vote' | 'stats' | 'results') {
   activeTab.value = tab;
-  router.replace({ hash: `#${tab}` });
+  // preserve existing query params when updating the hash so the game id
+  // remains in the url, e.g. /games/PyramidTier?game=foo#stats
+  router.replace({
+    hash: `#${tab}`,
+    query: { ...route.query },
+  });
   console.log('PyramidNav: Set active tab to:', tab);
 }
 </script>


### PR DESCRIPTION
## Summary
- preserve query params when switching tabs in PyramidNav so game ID stays in the URL

## Testing
- `pnpm build` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_b_686a956a6460832fae5e2195f8bf214b