### PR TITLE
Fix image sharing on mobile and desktop

### DIFF
--- a/apps/client/src/components/PyramidImage.vue
+++ b/apps/client/src/components/PyramidImage.vue
@@ -440,6 +440,12 @@ function toRoman(num: number): string {
   return numerals[num - 1] || `${num}`;
 }
 
+function getImageDataUrl(): string | null {
+  return generatedImage.value;
+}
+
+defineExpose({ getImageDataUrl });
+
 
 </script>
 

--- a/apps/client/src/components/PyramidMyVote.vue
+++ b/apps/client/src/components/PyramidMyVote.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="pyramid-my-vote">
     <!-- <h2 class="subtitle has-text-white">My Vote</h2> -->
-    <div ref="canvasElement">
+    <div>
       <PyramidImage
+        ref="pyramidImageRef"
         :pyramid="pyramid"
         :worst-item="worstItem"
         :rows="rows"
@@ -31,14 +32,14 @@
       />
       <ShareButton
         :share-text="shareText || 'Check out my TOP-X Pyramid ranking! #TOPX'"
-        :canvas-element="canvasElement"
+        :image-url="imageUrl"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { doc, setDoc, runTransaction } from 'firebase/firestore';
 import { db } from '@top-x/shared';
@@ -52,7 +53,8 @@ import { PyramidItem, PyramidRow, PyramidSlot, PyramidData } from '@top-x/shared
 
 const router = useRouter();
 const userStore = useUserStore();
-const canvasElement = ref<HTMLElement | null>(null);
+const pyramidImageRef = ref<any>(null);
+const imageUrl = computed(() => pyramidImageRef.value?.getImageDataUrl() || null);
 
 const props = defineProps<{
   pyramid: PyramidSlot[][];

--- a/apps/client/src/components/ShareButton.vue
+++ b/apps/client/src/components/ShareButton.vue
@@ -11,12 +11,11 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue';
-import html2canvas from 'html2canvas';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
 
 const props = defineProps<{
   shareText: string;
-  canvasElement: HTMLElement | null; // Allow null to fix TypeScript error
+  imageUrl: string | null;
 }>();
 
 // Check if Web Share API is supported
@@ -24,82 +23,27 @@ const isShareSupported = computed(() => !!navigator.share && !!navigator.canShar
 
 // Detect Android for fallback
 const isAndroid = computed(() => /Android/i.test(navigator.userAgent));
+const isIOS = computed(() => /iPad|iPhone|iPod/i.test(navigator.userAgent));
+const isMobile = computed(() => isAndroid.value || isIOS.value);
 
 const handleShare = async () => {
-  if (!props.canvasElement) {
-    console.error('ShareButton: No canvas element provided');
-    alert('Cannot share: No content to capture.');
+  if (!props.imageUrl) {
+    console.error('ShareButton: No image URL provided');
+    alert('Cannot share: No image available.');
     return;
   }
 
   try {
-    // For Android, prefer fallback due to inconsistent Web Share API support
-    if (isAndroid.value) {
-      await tryAndroidFallback();
+    const blob = await (await fetch(props.imageUrl)).blob();
+    const file = new File([blob], 'top-x-pyramid.png', { type: blob.type || 'image/png' });
+
+    if (isMobile.value && navigator.canShare && navigator.canShare({ files: [file] })) {
+      await navigator.share({ files: [file], text: props.shareText });
+      console.log('Shared successfully');
       return;
     }
-      
-    // Generate image from canvas element
-    const canvas = await html2canvas(props.canvasElement, {
-      backgroundColor: '#000000', // Match TOP-X dark theme
-      scale: 2, // Improve image quality
-    });
-    const blob = await new Promise<Blob | null>((resolve) =>
-      canvas.toBlob(resolve, 'image/png')
-    );
 
-    if (!blob) {
-      throw new Error('Failed to generate image from canvas');
-    }
-
-    // Create a File object for sharing
-    const file = new File([blob], 'top-x-pyramid.png', { type: 'image/png' });
-
-    // // Share data
-    // const shareData: ShareData = {
-    //   text: props.shareText,
-    //   files: [file],
-    // };
-
-    // Verify if share data can be shared
-    if (navigator.canShare && navigator.canShare({ files: [file] })) {
-     await navigator.share({
-          files: [file],
-         // title: shareTitle,
-          text: props.shareText,
-        });
-      console.log('Shared successfully to X');
-    } else {
-      throw new Error('Sharing not supported for this data');
-    }
-  } catch (error) {
-    console.error('Share failed:', error);
-    await tryAndroidFallback();
-  }
-};
-
-const tryAndroidFallback = async () => {
-  if (!props.canvasElement) {
-    console.error('ShareButton: No canvas element provided in fallback');
-    alert('Cannot share: No content to capture.');
-    return;
-  }
-
-  try {
-    // Generate image blob
-    const canvas = await html2canvas(props.canvasElement, {
-      backgroundColor: '#000000',
-      scale: 2,
-    });
-    const blob = await new Promise<Blob | null>((resolve) =>
-      canvas.toBlob(resolve, 'image/png')
-    );
-
-    if (!blob) {
-      throw new Error('Failed to generate image');
-    }
-
-    // Download image
+    // Desktop or fallback behaviour
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
@@ -109,18 +53,16 @@ const tryAndroidFallback = async () => {
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
 
-    // Open X with pre-filled text
-    const xUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(props.shareText)}`;
-    window.open(xUrl, '_blank');
-
-    // Prompt user
-    alert(
-      'Image downloaded! Please open the X app, create a post with the downloaded image, and use this text: ' +
-        props.shareText
-    );
+    try {
+      await navigator.clipboard.writeText(props.shareText);
+      alert('Image downloaded and text copied to clipboard.');
+    } catch (err) {
+      console.error('Clipboard copy failed:', err);
+      alert('Image downloaded. Copy this text for your post: ' + props.shareText);
+    }
   } catch (error) {
-    console.error('Android fallback failed:', error);
-    alert('Failed to share. Please try again or share manually.');
+    console.error('Share failed:', error);
+    alert('Failed to share. Please try again.');
   }
 };
 </script>


### PR DESCRIPTION
## Summary
- expose generated pyramid image data URL from `PyramidImage`
- update `PyramidMyVote` to use the exposed image and pass it to `ShareButton`
- rewrite `ShareButton` to share using the image URL and handle desktop fallback

## Testing
- `pnpm -r build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_686a9915fb1c832fac5d9fab743747b9