### PR TITLE
Fix login refresh logic

### DIFF
--- a/apps/client/src/components/NavBar.vue
+++ b/apps/client/src/components/NavBar.vue
@@ -71,8 +71,8 @@ const router = useRouter();
 const isMenuActive = ref(false);
 
 const user = computed(() => {
-  console.log('NavBar user state:', userStore.user);
-  return userStore.user;
+  console.log('NavBar user state:', userStore.user.value);
+  return userStore.user.value;
 });
 const error = computed(() => userStore.error);
 

--- a/apps/client/src/components/PyramidImage.vue
+++ b/apps/client/src/components/PyramidImage.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, onMounted, nextTick, watch } from 'vue';
 import { useUserStore } from '@/stores/user';
 import { PyramidItem, PyramidRow, PyramidSlot } from '@top-x/shared/types/pyramid';
 import html2canvas from 'html2canvas';
@@ -50,6 +50,15 @@ onMounted(async () => {
   await nextTick();
   await renderPyramidImage();
 });
+
+watch(
+  [() => props.pyramid, () => props.worstItem, () => userStore.user],
+  async () => {
+    await nextTick();
+    await renderPyramidImage();
+  },
+  { deep: true }
+);
 
 async function preloadImages() {
   const imagePromises: Promise<void>[] = [];

--- a/apps/client/src/components/PyramidLoginPopup.vue
+++ b/apps/client/src/components/PyramidLoginPopup.vue
@@ -50,8 +50,7 @@ async function loginWithX() {
       const voteData = props.pendingVote || JSON.parse(localStorage.getItem(`pyramid_${props.gameId}`) || '{}');
       if (voteData && voteData.pyramid && 'worstItem' in voteData) {
         await saveCachedVote(voteData, userStore.user.uid);
-        localStorage.removeItem(`pyramid_${props.gameId}`);
-        console.log('PyramidLoginPopup: Vote saved and localStorage cleared');
+        console.log('PyramidLoginPopup: Vote saved');
       }
       emit('login');
     }


### PR DESCRIPTION
## Summary
- refresh pyramid image after login
- show login/logout button correctly
- keep pyramid edits after login

## Testing
- `pnpm build:client` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b7f3e0708832f86b09cb66f66a1fc