### PR TITLE
Refactor login action names

### DIFF
--- a/apps/client/src/components/NavBar.vue
+++ b/apps/client/src/components/NavBar.vue
@@ -40,7 +40,7 @@
   type="is-primary"
   label="Login with"
   :icon="['fab', 'x-twitter']"
-  @click="loginWithX"
+  @click="handleLogin"
 />
 
             <CustomButton
@@ -76,7 +76,7 @@ const user = computed(() => {
 });
 const error = computed(() => userStore.error);
 
-const loginWithX = async () => {
+const handleLogin = async () => {
   console.log('Initiating login with X');
   await userStore.loginWithX();
   if (userStore.user && userStore.profile) {

--- a/apps/client/src/components/PyramidLoginPopup.vue
+++ b/apps/client/src/components/PyramidLoginPopup.vue
@@ -13,7 +13,7 @@
         We only use your username and image, and we’ll never post on your behalf.
       </p>
       <div class="buttons">
-        <button class="button is-success" @click="loginWithX">Log in with X</button>
+        <button class="button is-success" @click="handleLogin">Log in with X</button>
         <button class="button is-text has-text-white" @click="skip">Skip for now</button>
       </div>
     </div>
@@ -42,7 +42,7 @@ const emit = defineEmits<{
 
 const userStore = useUserStore();
 
-async function loginWithX() {
+async function handleLogin() {
   try {
     const success = await userStore.loginWithX();
     if (success && userStore.user && props.gameId) {


### PR DESCRIPTION
## Summary
- unify login function naming so `loginWithX` is only defined in the user store
- update NavBar and PyramidLoginPopup components to call the store function via local handlers

## Testing
- `pnpm build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_686b8ae8f844832f804027348051a0db