### PR TITLE
Add active/source fields to PyramidItem

### DIFF
--- a/apps/admin/src/components/PyramidItemList.vue
+++ b/apps/admin/src/components/PyramidItemList.vue
@@ -16,6 +16,8 @@
             <p class="subtitle is-7 has-text-grey-light">Name: {{ item.name }}</p>
             <p class="subtitle is-7 has-text-grey-light">ID: {{ item.id }}</p>
             <p v-if="item.color" class="has-text-grey-light">Color: {{ item.color }}</p>
+            <p class="subtitle is-7 has-text-grey-light">Active: {{ item.active ? 'Yes' : 'No' }}</p>
+            <p class="subtitle is-7 has-text-grey-light">Source: {{ item.source }}</p>
           </div>
         </div>
         <div class="buttons mt-2">
@@ -144,7 +146,14 @@ const createNew = () => {
     return;
   }
   console.log('createNew called, emitting edit with new item');
-  emit('edit', { id: '', src: '', label: '', name: '' });
+  emit('edit', {
+    id: '',
+    src: '',
+    label: '',
+    name: '',
+    active: true,
+    source: 'topx',
+  });
 };
 
 const refresh = () => {

--- a/apps/admin/src/components/PyramidItemRecord.vue
+++ b/apps/admin/src/components/PyramidItemRecord.vue
@@ -31,6 +31,18 @@
         <input v-model="localItem.color" class="input" type="text" placeholder="e.g., #FF0000" />
       </div>
     </div>
+    <div class="field">
+      <label class="label has-text-white">Active</label>
+      <div class="control">
+        <input type="checkbox" v-model="localItem.active" />
+      </div>
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Source</label>
+      <div class="control">
+        <input v-model="localItem.source" class="input" type="text" placeholder="e.g., topx" />
+      </div>
+    </div>
     <div class="field is-grouped">
       <div class="control">
         <CustomButton type="is-primary" label="Save" @click="save" :disabled="isSaving" />
@@ -65,7 +77,11 @@ const emit = defineEmits<{
 }>();
 
 const userStore = useUserStore();
-const localItem = ref<PyramidItem>({ ...props.item });
+const localItem = ref<PyramidItem>({
+  active: true,
+  source: 'topx',
+  ...props.item,
+});
 const isSaving = ref(false);
 const error = ref<string | null>(null);
 const success = ref<string | null>(null);

--- a/apps/client/src/components/PyramidEdit.vue
+++ b/apps/client/src/components/PyramidEdit.vue
@@ -246,7 +246,8 @@ watch(
       imagePool.value = [];
       return;
     }
-    const sorted = [...newItems].sort((a, b) => {
+    const filtered = newItems.filter(item => item.active !== false);
+    const sorted = [...filtered].sort((a, b) => {
       const field = props.sortItems.orderBy;
       const dir = props.sortItems.order === 'asc' ? 1 : -1;
       const valA = a[field as keyof PyramidItem] || '';

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -5,6 +5,8 @@ export interface PyramidItem {
   src: string;
   description?: string;
   color?: string;
+  active: boolean;
+  source: string;
 }
 
 export interface SortOption {


### PR DESCRIPTION
## Summary
- extend `PyramidItem` type with `active` and `source`
- default new admin items to `active: true` and `source: 'topx'`
- expose `active` and `source` controls in admin UI
- hide inactive items from the edit pool in the client

## Testing
- `pnpm build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_686c1cd3b654832fa3809f1584ece23f