### PR TITLE
Add worstShow and instructions support

### DIFF
--- a/apps/admin/src/components/GameList.vue
+++ b/apps/admin/src/components/GameList.vue
@@ -115,10 +115,13 @@ const createNew = () => {
           shareImageTitle: '',
           poolHeader: '',
           worstHeader: '',
-          worstPoints: 0
+          worstPoints: 0,
+          worstShow: true,
+          communityItems: []
         }, // Default for PyramidConfig
         gameHeader: '',
         shareText: '',
+        gameInstruction: '',
         image: '',
         active: false,
       };

--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -32,6 +32,12 @@
       </div>
     </div>
     <div class="field">
+      <label class="label has-text-white">Game Instruction (Optional)</label>
+      <div class="control">
+        <input v-model="localGame.gameInstruction" class="input" type="text" placeholder="How to play" />
+      </div>
+    </div>
+    <div class="field">
       <label class="label has-text-white">Image URL</label>
       <div class="control">
         <input v-model="localGame.image" class="input" type="text" placeholder="https://example.com/image.png" />
@@ -95,6 +101,12 @@
         <label class="label has-text-white">Worst Points</label>
         <div class="control">
           <input v-model.number="(localGame.custom as PyramidConfig).worstPoints" class="input" type="number" />
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Show Worst Item</label>
+        <div class="control">
+          <input type="checkbox" v-model="(localGame.custom as PyramidConfig).worstShow" />
         </div>
       </div>
     </div>
@@ -173,13 +185,30 @@ if (
 ) {
   (localGame.value.custom as PyramidConfig).worstHeader = '';
 }
-if (
-  'custom' in localGame.value &&
-  (localGame.value.custom as any) &&
-  (localGame.value.custom as any).worstPoints === undefined
-) {
-  (localGame.value.custom as PyramidConfig).worstPoints = 0;
-}
+  if (
+    'custom' in localGame.value &&
+    (localGame.value.custom as any) &&
+    (localGame.value.custom as any).worstPoints === undefined
+  ) {
+    (localGame.value.custom as PyramidConfig).worstPoints = 0;
+  }
+  if (
+    'custom' in localGame.value &&
+    (localGame.value.custom as any) &&
+    (localGame.value.custom as any).worstShow === undefined
+  ) {
+    (localGame.value.custom as PyramidConfig).worstShow = true;
+  }
+  if (
+    'custom' in localGame.value &&
+    (localGame.value.custom as any) &&
+    (localGame.value.custom as any).communityItems === undefined
+  ) {
+    (localGame.value.custom as PyramidConfig).communityItems = [];
+  }
+  if (localGame.value.gameInstruction === undefined) {
+    (localGame.value as any).gameInstruction = '';
+  }
 const isSaving = ref(false);
 const error = ref<string | null>(null);
 const success = ref<string | null>(null);
@@ -241,28 +270,34 @@ const save = async () => {
   let customData: PyramidConfig | TriviaConfig;
   if (gameTypeCustom.value === 'PyramidConfig') {
     console.log('Processing PyramidConfig');
-    customData = {
-      items: 'items' in (localGame.value.custom || {}) ? (localGame.value.custom as PyramidConfig).items : [],
-      rows: 'rows' in (localGame.value.custom || {}) ? (localGame.value.custom as PyramidConfig).rows : [],
-      sortItems: 'sortItems' in (localGame.value.custom || {})
-        ? (localGame.value.custom as PyramidConfig).sortItems
-        : { orderBy: 'id', order: 'asc' },
-      HideRowLabel: 'HideRowLabel' in (localGame.value.custom || {})
-        ? (localGame.value.custom as PyramidConfig).HideRowLabel
-        : false,
-      shareImageTitle: 'shareImageTitle' in (localGame.value.custom || {})
-        ? (localGame.value.custom as PyramidConfig).shareImageTitle
-        : undefined,
-      poolHeader: 'poolHeader' in (localGame.value.custom || {})
-        ? (localGame.value.custom as PyramidConfig).poolHeader
-        : undefined,
-      worstHeader: 'worstHeader' in (localGame.value.custom || {})
-        ? (localGame.value.custom as PyramidConfig).worstHeader
-        : undefined,
-      worstPoints: 'worstPoints' in (localGame.value.custom || {})
-        ? (localGame.value.custom as PyramidConfig).worstPoints
-        : undefined,
-    };
+      customData = {
+        items: 'items' in (localGame.value.custom || {}) ? (localGame.value.custom as PyramidConfig).items : [],
+        rows: 'rows' in (localGame.value.custom || {}) ? (localGame.value.custom as PyramidConfig).rows : [],
+        sortItems: 'sortItems' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).sortItems
+          : { orderBy: 'id', order: 'asc' },
+        HideRowLabel: 'HideRowLabel' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).HideRowLabel
+          : false,
+        shareImageTitle: 'shareImageTitle' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).shareImageTitle
+          : undefined,
+        poolHeader: 'poolHeader' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).poolHeader
+          : undefined,
+        worstHeader: 'worstHeader' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).worstHeader
+          : undefined,
+        worstPoints: 'worstPoints' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).worstPoints
+          : undefined,
+        worstShow: 'worstShow' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).worstShow
+          : true,
+        communityItems: 'communityItems' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).communityItems
+          : [],
+      };
     console.log('PyramidConfig customData created:', customData);
   } else if (gameTypeCustom.value === 'TriviaConfig') {
     customData = {
@@ -284,6 +319,7 @@ const save = async () => {
       custom: customData,
       gameHeader: localGame.value.gameHeader || null,
       shareText: localGame.value.shareText || null,
+      gameInstruction: localGame.value.gameInstruction || null,
       image: localGame.value.image || '',
       active: localGame.value.active || false,
     };
@@ -306,5 +342,4 @@ fetchGameTypeCustom();
 <style scoped>
 .mt-3 {
   margin-top: 1rem;
-}
-</style>
+}</style>

--- a/apps/client/src/components/PyramidEdit.vue
+++ b/apps/client/src/components/PyramidEdit.vue
@@ -44,7 +44,7 @@
       </div>
 
       <!-- Worst Item Slot -->
-      <div class="worst-item-container">
+      <div v-if="worstShow" class="worst-item-container">
         <h3 class="subtitle has-text-centered has-text-white" style="margin-bottom:5px;font-size: 18px">{{ props.worstHeader }}</h3>
         <div class="worst-row-wrapper">
           <div
@@ -152,6 +152,7 @@ const props = defineProps<{
   worstHeader?: string;
   shareText?: string;
   worstPoints?: number;
+  worstShow?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -171,6 +172,7 @@ const selectedItem = ref<PyramidItem | null>(null);
 const droppableSlot = ref<{ row: number; col: number } | null>(null);
 const animatedPoints = ref<string | null>(null);
 const worstAnimatedPoints = ref<string | null>(null);
+const worstShow = computed(() => props.worstShow ?? true);
 
 // Description Tab State
 const showTab = ref(false);

--- a/apps/client/src/components/PyramidImage.vue
+++ b/apps/client/src/components/PyramidImage.vue
@@ -33,6 +33,7 @@ const props = defineProps<{
   userProfile?: { photoURL: string };
   shareImageTitle?: string;
   shareText?: string;
+  worstShow?: boolean;
 }>();
 
 const userStore = useUserStore();
@@ -55,7 +56,7 @@ onMounted(async () => {
 });
 
 watch(
-  [() => props.pyramid, () => props.worstItem, () => props.userProfile?.photoURL],
+  [() => props.pyramid, () => props.worstItem, () => props.userProfile?.photoURL, () => props.worstShow],
   async () => {
     console.log('PyramidView: Detected change in pyramid, worstItem, or userProfile, re-rendering');
     await nextTick();
@@ -402,13 +403,15 @@ async function renderPyramidImage() {
             )
             .join('')}
         </div>
-        <div class="worst-item-container">
+        ${
+          props.worstShow === false
+            ? ''
+            : `<div class="worst-item-container">
           <h3 class="subtitle has-text-centered has-text-white">${props.worstHeader || 'Worst Item'}</h3>
           <div class="pyramid-slot box worst-slot dark-slot">
             ${
               props.worstItem
-                ? `
-              <div class="slot-style">
+                ? `<div class="slot-style">
                 <img
                   src="${preprocessedImages.value.get(props.worstItem.src) || props.worstItem.src}"
                   alt="${props.worstItem.label}"
@@ -420,7 +423,8 @@ async function renderPyramidImage() {
                 : `<div class="tier-label has-text-danger">Worst</div>`
             }
           </div>
-        </div>
+        </div>`
+        }
         <p class="top-x-label has-text-white has-text-centered">
           And what’s your vote? -> https://top-x.co/PrezPyramid
         </p>

--- a/apps/client/src/components/PyramidMyVote.vue
+++ b/apps/client/src/components/PyramidMyVote.vue
@@ -12,6 +12,7 @@
         :share-image-title="shareImageTitle"
         :share-text="shareText"
         :hide-row-label="hideRowLabel"
+        :worst-show="worstShow"
         :user-profile="{ photoURL: userStore.user?.photoURL || '' }"
       />
     </div>
@@ -68,6 +69,7 @@ const props = defineProps<{
   worstPoints?: number;
   shareImageTitle?: string;
   shareText?: string;
+  worstShow?: boolean;
 }>();
 
 onMounted(() => {

--- a/apps/client/src/components/PyramidNav.vue
+++ b/apps/client/src/components/PyramidNav.vue
@@ -25,6 +25,7 @@
         :share-image-title="shareImageTitle"
         :share-text="shareText"
         :hide-row-label="hideRowLabel"
+        :worst-show="worstShow"
         :game-id="gameId"
       />
       <PyramidStats
@@ -35,6 +36,7 @@
         :worstPoints="worstPoints ?? 0"
         :game-header="gameHeader"
         :game-title="gameTitle"
+        :worst-show="worstShow"
       />
       <PyramidResults
         v-if="activeTab === 'results'"
@@ -76,6 +78,7 @@ const props = defineProps<{
   worstPoints?: number;
   shareImageTitle?: string;
   shareText?: string;
+  worstShow?: boolean;
 }>();
 
 const activeTab = ref<'my-vote' | 'stats' | 'results'>('my-vote');

--- a/apps/client/src/components/PyramidStats.vue
+++ b/apps/client/src/components/PyramidStats.vue
@@ -30,7 +30,7 @@
                 />
               </a>
             </th>
-            <th class="has-text-centered">
+            <th v-if="worstShow" class="has-text-centered">
               <a href="#" class="has-text-white" @click.prevent="sortBy('worst')">💩
                 <font-awesome-icon
                   v-if="sortColumn === 'worst'"
@@ -88,7 +88,7 @@
             <td v-for="row in props.rows" :key="row.id" class="has-text-centered number-cell">
               {{ formatNumber(item.ranks[row.id] || 0) }}
             </td>
-            <td class="has-text-centered number-cell">{{ formatNumber(item.worstCounts || 0) }}</td>
+            <td v-if="worstShow" class="has-text-centered number-cell">{{ formatNumber(item.worstCounts || 0) }}</td>
             <td class="has-text-centered number-cell">{{ formatNumber(item.score) }}</td>
           </tr>
         </tbody>
@@ -116,7 +116,7 @@
                 {{ row.label || toRoman(row.id) }}: {{ formatNumber(selectedPresident?.ranks[row.id] || 0) }}
               </li>
             </ul>
-                        <p class="has-text-white">💩 {{ formatNumber(selectedPresident?.worstCounts || 0) }}</p>
+                        <p v-if="worstShow" class="has-text-white">💩 {{ formatNumber(selectedPresident?.worstCounts || 0) }}</p>
 
             <p class="has-text-white">Total Players: {{ formatNumber(totalPlayers) }}</p>
           </div>
@@ -157,7 +157,10 @@ const props = defineProps<{
   items: PyramidItem[];
   rows: PyramidRow[];
   worstPoints: number;
+  worstShow?: boolean;
 }>();
+
+const worstShow = computed(() => props.worstShow !== false);
 
 const sortColumn = ref<string>('score');
 const sortDirection = ref<'asc' | 'desc'>('desc');

--- a/apps/client/src/views/games/PyramidTier.vue
+++ b/apps/client/src/views/games/PyramidTier.vue
@@ -12,6 +12,7 @@
       :worst-header="worstHeader"
       :share-text="shareText"
       :worst-points="worstPoints"
+      :worst-show="worstShow"
       @submit="handleSubmit"
     />
     <PyramidNav
@@ -28,6 +29,7 @@
       :share-text="shareText"
       :hide-row-label="hideRowLabel"
       :worst-points="worstPoints"
+      :worst-show="worstShow"
     />
   </div>
 </template>
@@ -66,6 +68,7 @@ const worstHeader = ref('Worst Item');
 const shareText = ref('');
 const baseShareText = ref('');
 const worstPoints = ref(0);
+const worstShow = ref(true);
 const shareImageTitle = ref('');
 const hasSubmitted = ref(false);
 const pyramid = ref<PyramidSlot[][]>([
@@ -120,6 +123,7 @@ onMounted(async () => {
       sortItems.value = gameData.custom?.sortItems || { orderBy: 'id', order: 'asc' };
       hideRowLabel.value = gameData.custom?.HideRowLabel ?? false;
       worstPoints.value = gameData.custom?.worstPoints ?? 0;
+      worstShow.value = gameData.custom?.worstShow !== false;
 
       console.log('PyramidTier: Game data fetched:', {
         gameTitle: gameTitle.value,
@@ -133,7 +137,8 @@ onMounted(async () => {
         rows: rows.value,
         sortItems: sortItems.value,
         hideRowLabel: hideRowLabel.value,
-        worstPoints: worstPoints.value
+        worstPoints: worstPoints.value,
+        worstShow: worstShow.value
       });
     } else {
       console.error('PyramidTier: Game document not found for ID:', gameId.value);

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -17,10 +17,11 @@ export interface Game {
   active: boolean;
   gameHeader?: string;
   shareText?: string;
+  /** Instructions displayed to the user before playing */
+  gameInstruction?: string;
   image: string;
   custom: PyramidConfig | TriviaConfig; // Union of possible config types
 }
 
 export type ConfigType = 'PyramidConfig' | 'TriviaConfig';
-
 export const CONFIG_TYPES: ConfigType[] = ['PyramidConfig', 'TriviaConfig'];

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -22,6 +22,14 @@ export interface PyramidConfig {
   poolHeader?: string;
   worstHeader?: string;
   worstPoints?: number;
+  /**
+   * Flag to show or hide the worst item column. Defaults to true.
+   */
+  worstShow?: boolean;
+  /**
+   * Additional items contributed by the community.
+   */
+  communityItems: PyramidItem[];
 }
 export interface PyramidRow {
   id: number;
@@ -41,5 +49,4 @@ export interface PyramidData {
 export interface PyramidStats {
   itemRanks: { [itemId: string]: { [tierId: string]: number } };
   totalPlayers: number;
-  worstItemCounts: { [itemId: string]: number };
-}
+  worstItemCounts: { [itemId: string]: number };}


### PR DESCRIPTION
## Summary
- expand `PyramidConfig` with `worstShow` and `communityItems`
- expand `Game` with optional `gameInstruction`
- expose new fields in admin forms and defaults
- pass `worstShow` down through pyramid components
- hide worst item column when `worstShow` is disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d1397be80832fb9db88edca9979fd