### PR TITLE
Add gameInstruction support

### DIFF
--- a/apps/client/src/components/PyramidEdit.vue
+++ b/apps/client/src/components/PyramidEdit.vue
@@ -2,7 +2,7 @@
   <section class="section">
     <div class="container has-text-centered">
       <h2 class="subtitle has-text-success" v-html="props.gameHeader"></h2>
-      <h2 class="has-text-white" style="margin-bottom: 1rem;">Rank your favorite U.S. presidents <br/> from top to bottom</h2>
+      <h2 class="has-text-white" style="margin-bottom: 1rem;" v-html="props.gameInstruction"></h2>
 
       <div class="pyramid">
         <div v-for="(row, rowIndex) in pyramid" :key="rowIndex" class="pyramid-row-container">
@@ -182,6 +182,7 @@ const props = defineProps<{
   sortItems: SortOption;
   hideRowLabel: boolean;
   gameHeader: string;
+  gameInstruction?: string;
   poolHeader?: string;
   worstHeader?: string;
   shareText?: string;

--- a/apps/client/src/views/games/PyramidTier.vue
+++ b/apps/client/src/views/games/PyramidTier.vue
@@ -8,6 +8,7 @@
       :sort-items="sortItems"
       :hide-row-label="hideRowLabel"
       :game-header="gameHeader"
+      :game-instruction="gameInstruction"
       :pool-header="poolHeader"
       :worst-header="worstHeader"
       :share-text="shareText"
@@ -63,6 +64,7 @@ const rows = ref<PyramidRow[]>([]);
 const sortItems = ref<SortOption>({ orderBy: 'id', order: 'asc' });
 const hideRowLabel = ref(false);
 const gameHeader = ref('Your Pyramid');
+const gameInstruction = ref('');
 const poolHeader = ref('Item Pool');
 const worstHeader = ref('Worst Item');
 const shareText = ref('');
@@ -113,6 +115,7 @@ onMounted(async () => {
       gameTitle.value = gameData.name || '';
       gameDescription.value = gameData.description || '';
       gameHeader.value = gameData.gameHeader || 'Your Pyramid';
+      gameInstruction.value = gameData.gameInstruction || '';
       poolHeader.value = gameData.custom?.poolHeader || 'Item Pool';
       worstHeader.value = gameData.custom?.worstHeader || 'Worst Item';
       baseShareText.value = gameData.shareText || '';
@@ -129,6 +132,7 @@ onMounted(async () => {
         gameTitle: gameTitle.value,
         gameDescription: gameDescription.value,
         gameHeader: gameHeader.value,
+        gameInstruction: gameInstruction.value,
         poolHeader: poolHeader.value,
         worstHeader: worstHeader.value,
         shareText: shareText.value,


### PR DESCRIPTION
## Summary
- add `gameInstruction` prop to PyramidEdit to show dynamic instructions
- fetch and pass `gameInstruction` in PyramidTier

## Testing
- `pnpm build:shared` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_686e3f21cbd4832f875c8e84379ec188