### PR TITLE
Add name sort option

### DIFF
--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -60,6 +60,7 @@
             <option value="id">ID</option>
             <option value="label">Label</option>
             <option value="color">Color</option>
+            <option value="name">Name</option>
           </select>
         </div>
       </div>

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -10,7 +10,7 @@ export interface PyramidItem {
 }
 
 export interface SortOption {
-  orderBy: 'id' | 'label' | 'color';
+  orderBy: 'id' | 'label' | 'color' | 'name';
   order: 'asc' | 'desc';
 }
 export interface PyramidConfig {


### PR DESCRIPTION
## Summary
- allow items to be sorted by `name` as well as `id`, `label` or `color`
- expose the new "Name" option in the admin UI

## Testing
- `pnpm build:shared` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_686e7eadc83c832f842ade5b6107a761