### PR TITLE
Add community header and language fields

### DIFF
--- a/apps/admin/src/components/GameList.vue
+++ b/apps/admin/src/components/GameList.vue
@@ -114,6 +114,7 @@ const createNew = () => {
           HideRowLabel: false,
           shareImageTitle: '',
           poolHeader: '',
+          communityHeader: '',
           worstHeader: '',
           worstPoints: 0,
           worstShow: true,
@@ -122,6 +123,8 @@ const createNew = () => {
         gameHeader: '',
         shareText: '',
         gameInstruction: '',
+        language: 'en',
+        shareLink: '',
         image: '',
         active: false,
       };

--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -38,6 +38,21 @@
       </div>
     </div>
     <div class="field">
+      <label class="label has-text-white">Language</label>
+      <div class="control select">
+        <select v-model="localGame.language">
+          <option value="en">English</option>
+          <option value="il">Hebrew</option>
+        </select>
+      </div>
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Share Link (Optional)</label>
+      <div class="control">
+        <input v-model="localGame.shareLink" class="input" type="text" placeholder="https://example.com" />
+      </div>
+    </div>
+    <div class="field">
       <label class="label has-text-white">Image URL</label>
       <div class="control">
         <input v-model="localGame.image" class="input" type="text" placeholder="https://example.com/image.png" />
@@ -91,6 +106,12 @@
           <div class="control">
             <input v-model="(localGame.custom as PyramidConfig).poolHeader" class="input" type="text" placeholder="e.g., Question Pool" />
           </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white">Community Header (Optional)</label>
+        <div class="control">
+          <input v-model="(localGame.custom as PyramidConfig).communityHeader" class="input" type="text" placeholder="e.g., Community Picks" />
+        </div>
       </div>
       <div class="field">
         <label class="label has-text-white">Worst Header (Optional)</label>
@@ -150,7 +171,7 @@ const emit = defineEmits<{
 }>();
 
 const userStore = useUserStore();
-const localGame = ref<Game>({ image: '', active: false, ...props.game });
+const localGame = ref<Game>({ language: 'en', image: '', active: false, ...props.game });
 if (
   'custom' in localGame.value &&
   (localGame.value.custom as any) &&
@@ -207,8 +228,21 @@ if (
   ) {
     (localGame.value.custom as PyramidConfig).communityItems = [];
   }
+  if (
+    'custom' in localGame.value &&
+    (localGame.value.custom as any) &&
+    (localGame.value.custom as any).communityHeader === undefined
+  ) {
+    (localGame.value.custom as PyramidConfig).communityHeader = '';
+  }
   if (localGame.value.gameInstruction === undefined) {
     (localGame.value as any).gameInstruction = '';
+  }
+  if (localGame.value.language === undefined) {
+    localGame.value.language = 'en';
+  }
+  if ((localGame.value as any).shareLink === undefined) {
+    (localGame.value as any).shareLink = '';
   }
 const isSaving = ref(false);
 const error = ref<string | null>(null);
@@ -298,6 +332,9 @@ const save = async () => {
         communityItems: 'communityItems' in (localGame.value.custom || {})
           ? (localGame.value.custom as PyramidConfig).communityItems
           : [],
+        communityHeader: 'communityHeader' in (localGame.value.custom || {})
+          ? (localGame.value.custom as PyramidConfig).communityHeader
+          : undefined,
       };
     console.log('PyramidConfig customData created:', customData);
   } else if (gameTypeCustom.value === 'TriviaConfig') {
@@ -321,6 +358,8 @@ const save = async () => {
       gameHeader: localGame.value.gameHeader || null,
       shareText: localGame.value.shareText || null,
       gameInstruction: localGame.value.gameInstruction || null,
+      language: localGame.value.language || 'en',
+      shareLink: localGame.value.shareLink || null,
       image: localGame.value.image || '',
       active: localGame.value.active || false,
     };

--- a/apps/admin/src/components/PyramidItemRecord.vue
+++ b/apps/admin/src/components/PyramidItemRecord.vue
@@ -26,6 +26,12 @@
       </div>
     </div>
     <div class="field">
+      <label class="label has-text-white">Description (Optional)</label>
+      <div class="control">
+        <textarea v-model="localItem.description" class="textarea" placeholder="Item description"></textarea>
+      </div>
+    </div>
+    <div class="field">
       <label class="label has-text-white">Color (Optional)</label>
       <div class="control">
         <input v-model="localItem.color" class="input" type="text" placeholder="e.g., #FF0000" />
@@ -82,6 +88,9 @@ const localItem = ref<PyramidItem>({
   source: 'topx',
   ...props.item,
 });
+if (localItem.value.description === undefined) {
+  (localItem.value as any).description = '';
+}
 const isSaving = ref(false);
 const error = ref<string | null>(null);
 const success = ref<string | null>(null);

--- a/apps/client/src/components/PyramidEdit.vue
+++ b/apps/client/src/components/PyramidEdit.vue
@@ -134,6 +134,7 @@
           @click="showAddItemPopup"
         />
       </div>
+      <h2 v-if="props.communityHeader" class="subtitle has-text-white" style="font-size: 20px;">{{ props.communityHeader }}</h2>
       <ins class="adsbygoogle"
            style="display:block"
            :data-ad-client="adClient"
@@ -193,6 +194,7 @@ const props = defineProps<{
   gameHeader: string;
   gameInstruction?: string;
   poolHeader?: string;
+  communityHeader?: string;
   worstHeader?: string;
   shareText?: string;
   worstPoints?: number;

--- a/apps/client/src/components/PyramidImage.vue
+++ b/apps/client/src/components/PyramidImage.vue
@@ -33,6 +33,7 @@ const props = defineProps<{
   userProfile?: { photoURL: string };
   shareImageTitle?: string;
   shareText?: string;
+  shareLink?: string;
   worstShow?: boolean;
 }>();
 
@@ -426,7 +427,7 @@ async function renderPyramidImage() {
         </div>`
         }
         <p class="top-x-label has-text-white has-text-centered">
-          And what’s your vote? -> https://top-x.co/PrezPyramid
+          And what’s your vote? -> ${props.shareLink || 'https://top-x.co/PrezPyramid'}
         </p>
       </div>
     `;

--- a/apps/client/src/components/PyramidMyVote.vue
+++ b/apps/client/src/components/PyramidMyVote.vue
@@ -11,6 +11,7 @@
         :game-title="gameTitle"
         :share-image-title="shareImageTitle"
         :share-text="shareText"
+        :share-link="shareLink"
         :hide-row-label="hideRowLabel"
         :worst-show="worstShow"
         :user-profile="{ photoURL: userStore.user?.photoURL || '' }"
@@ -67,6 +68,7 @@ const props = defineProps<{
   worstPoints?: number;
   shareImageTitle?: string;
   shareText?: string;
+  shareLink?: string;
   worstShow?: boolean;
 }>();
 

--- a/apps/client/src/components/PyramidNav.vue
+++ b/apps/client/src/components/PyramidNav.vue
@@ -24,6 +24,7 @@
         :game-title="gameTitle"
         :share-image-title="shareImageTitle"
         :share-text="shareText"
+        :share-link="shareLink"
         :hide-row-label="hideRowLabel"
         :worst-show="worstShow"
         :game-id="gameId"
@@ -78,6 +79,7 @@ const props = defineProps<{
   worstPoints?: number;
   shareImageTitle?: string;
   shareText?: string;
+  shareLink?: string;
   worstShow?: boolean;
 }>();
 

--- a/apps/client/src/components/PyramidView.vue
+++ b/apps/client/src/components/PyramidView.vue
@@ -69,7 +69,7 @@
         </div>
       </div>
       <!-- Top-X Label -->
-      <p class="top-x-label has-text-white has-text-centered mt-2">And what’s your vote? <br /> top-x.co/PrezPyramid</p>
+      <p class="top-x-label has-text-white has-text-centered mt-2">And what’s your vote? <br /> {{ props.shareLink || 'top-x.co/PrezPyramid' }}</p>
     </div>
     <!-- Download & Share Buttons -->
     <div class="buttons is-centered mt-2">
@@ -116,6 +116,7 @@ const props = defineProps<{
   userProfile?: { photoURL: string };
   shareImageTitle?: string;
   shareText?: string;
+  shareLink?: string;
 }>();
 
 const userStore = useUserStore();

--- a/apps/client/src/views/Home.vue
+++ b/apps/client/src/views/Home.vue
@@ -55,6 +55,8 @@ interface Game {
   image: string;
   isComingSoon: boolean;
   active: boolean;
+  language: 'en' | 'il';
+  shareLink?: string;
   route: string;
 }
 
@@ -85,6 +87,8 @@ onMounted(() => {
         image: data.image || fallbackImg,
         isComingSoon: data.custom?.isComingSoon || false,
         active: data.active ?? false,
+        language: data.language || 'en',
+        shareLink: data.shareLink || '',
         route: data.gameTypeId === 'PyramidTier' ? `/games/PyramidTier?game=${doc.id}` : `/games/${data.gameTypeId}`,
       } as Game;
     }).filter(g => g.active);

--- a/apps/client/src/views/games/PyramidTier.vue
+++ b/apps/client/src/views/games/PyramidTier.vue
@@ -10,6 +10,7 @@
       :game-header="gameHeader"
       :game-instruction="gameInstruction"
       :pool-header="poolHeader"
+      :community-header="communityHeader"
       :worst-header="worstHeader"
       :share-text="shareText"
       :worst-points="worstPoints"
@@ -28,6 +29,7 @@
       :game-title="gameTitle"
       :share-image-title="shareImageTitle"
       :share-text="shareText"
+      :share-link="shareLink"
       :hide-row-label="hideRowLabel"
       :worst-points="worstPoints"
       :worst-show="worstShow"
@@ -72,6 +74,8 @@ const baseShareText = ref('');
 const worstPoints = ref(0);
 const worstShow = ref(true);
 const shareImageTitle = ref('');
+const shareLink = ref('');
+const communityHeader = ref('');
 const hasSubmitted = ref(false);
 const pyramid = ref<PyramidSlot[][]>([
   [{ image: null }],
@@ -117,10 +121,12 @@ onMounted(async () => {
       gameHeader.value = gameData.gameHeader || 'Your Pyramid';
       gameInstruction.value = gameData.gameInstruction || '';
       poolHeader.value = gameData.custom?.poolHeader || 'Item Pool';
+      communityHeader.value = gameData.custom?.communityHeader || '';
       worstHeader.value = gameData.custom?.worstHeader || 'Worst Item';
       baseShareText.value = gameData.shareText || '';
       updateShareText();
       shareImageTitle.value = gameData.custom?.shareImageTitle || '';
+      shareLink.value = gameData.shareLink || '';
       items.value = gameData.custom?.items || [];
       rows.value = gameData.custom?.rows || [];
       sortItems.value = gameData.custom?.sortItems || { orderBy: 'id', order: 'asc' };
@@ -134,9 +140,11 @@ onMounted(async () => {
         gameHeader: gameHeader.value,
         gameInstruction: gameInstruction.value,
         poolHeader: poolHeader.value,
+        communityHeader: communityHeader.value,
         worstHeader: worstHeader.value,
         shareText: shareText.value,
         shareImageTitle: shareImageTitle.value,
+        shareLink: shareLink.value,
         items: items.value,
         rows: rows.value,
         sortItems: sortItems.value,

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -19,6 +19,10 @@ export interface Game {
   shareText?: string;
   /** Instructions displayed to the user before playing */
   gameInstruction?: string;
+  /** Language for the game, either 'en' or 'il'. Defaults to 'en'. */
+  language: 'en' | 'il';
+  /** Optional link shown on shared images */
+  shareLink?: string;
   image: string;
   custom: PyramidConfig | TriviaConfig; // Union of possible config types
 }

--- a/packages/shared/src/types/pyramid.ts
+++ b/packages/shared/src/types/pyramid.ts
@@ -30,6 +30,10 @@ export interface PyramidConfig {
    * Additional items contributed by the community.
    */
   communityItems: PyramidItem[];
+  /**
+   * Optional header for the community items section
+   */
+  communityHeader?: string;
 }
 export interface PyramidRow {
   id: number;


### PR DESCRIPTION
## Summary
- extend `PyramidConfig` with optional `communityHeader`
- allow editing item descriptions in admin
- support `language`, `shareLink`, and `communityHeader` fields in admin game forms
- use new fields in client views and components
- expose language and share link properties in shared `Game` type
- display community header and customizable share link in pyramid components

## Testing
- `pnpm build:shared` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_b_68701680561c832faaf8ae5cac52f784