### PR TITLE
Add admin view for community items and preserve on save

### DIFF
--- a/apps/admin/src/components/CommunityItemList.vue
+++ b/apps/admin/src/components/CommunityItemList.vue
@@ -1,0 +1,159 @@
+<template>
+  <Card>
+    <h2 class="subtitle has-text-white">Community Items</h2>
+    <div v-if="isLoading" class="has-text-grey-light mt-3">Loading items...</div>
+    <div v-else-if="items.length" class="mt-3">
+      <div v-for="item in items" :key="item.id" class="box">
+        <div class="media">
+          <div class="media-left">
+            <figure class="image is-48x48">
+              <img :src="item.src" :alt="item.label" />
+            </figure>
+          </div>
+          <div class="media-content">
+            <p class="title is-6 has-text-white">{{ item.label }}</p>
+            <p class="subtitle is-7 has-text-grey-light">Name: {{ item.name }}</p>
+            <p class="subtitle is-7 has-text-grey-light">ID: {{ item.id }}</p>
+            <p v-if="item.color" class="has-text-grey-light">Color: {{ item.color }}</p>
+            <p class="subtitle is-7 has-text-grey-light">Active: {{ item.active ? 'Yes' : 'No' }}</p>
+            <p class="subtitle is-7 has-text-grey-light">Source: {{ item.source }}</p>
+          </div>
+        </div>
+        <div class="buttons mt-2">
+          <CustomButton type="is-danger" label="Delete" @click="deleteItem(item.id)" />
+        </div>
+      </div>
+    </div>
+    <p v-else class="has-text-grey-light mt-3">No community items found for this game.</p>
+    <p v-if="error" class="notification is-danger">{{ error }}</p>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, watch, computed } from 'vue';
+import { doc, getDoc, onSnapshot, updateDoc } from 'firebase/firestore';
+import { db } from '@top-x/shared';
+import { useUserStore } from '@/stores/user';
+import Card from '@top-x/shared/components/Card.vue';
+import CustomButton from '@top-x/shared/components/CustomButton.vue';
+import type { PyramidItem } from '@top-x/shared/types/pyramid';
+
+const props = defineProps<{
+  gameId: string | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'refresh'): void;
+}>();
+
+const userStore = useUserStore();
+const items = ref<PyramidItem[]>([]);
+const error = ref<string | null>(null);
+const isLoading = ref(false);
+let unsubscribe: (() => void) | null = null;
+
+const isAdmin = computed(() => userStore.user?.isAdmin || false);
+
+const fetchItems = async (gameId: string) => {
+  if (!gameId) {
+    error.value = 'No game selected';
+    isLoading.value = false;
+    items.value = [];
+    return;
+  }
+  isLoading.value = true;
+  error.value = null;
+  try {
+    const gameDocRef = doc(db, 'games', gameId);
+    const gameDoc = await getDoc(gameDocRef);
+    if (gameDoc.exists()) {
+      const gameData = gameDoc.data();
+      items.value = (gameData.custom?.communityItems || []) as PyramidItem[];
+    } else {
+      error.value = 'Game not found';
+      items.value = [];
+    }
+
+    if (unsubscribe) unsubscribe();
+    unsubscribe = onSnapshot(gameDocRef, (docSnap) => {
+      if (docSnap.exists()) {
+        const data = docSnap.data();
+        items.value = (data.custom?.communityItems || []) as PyramidItem[];
+      } else {
+        items.value = [];
+      }
+    }, (err) => {
+      console.error('CommunityItemList snapshot error:', err.message);
+    });
+  } catch (err: any) {
+    error.value = `Failed to fetch community items: ${err.message}`;
+    items.value = [];
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const deleteItem = async (itemId: string) => {
+  if (!isAdmin.value) {
+    error.value = 'Unauthorized: Admin access required';
+    return;
+  }
+  if (!props.gameId) {
+    error.value = 'No game selected';
+    return;
+  }
+  try {
+    const gameDocRef = doc(db, 'games', props.gameId);
+    const updatedItems = items.value.filter(item => item.id !== itemId);
+    await updateDoc(gameDocRef, { 'custom.communityItems': updatedItems });
+  } catch (err: any) {
+    error.value = `Failed to delete item: ${err.message}`;
+  }
+};
+
+const refresh = () => {
+  if (props.gameId) {
+    fetchItems(props.gameId);
+    emit('refresh');
+  }
+};
+
+onMounted(() => {
+  if (props.gameId) {
+    fetchItems(props.gameId);
+  }
+});
+
+watch(() => props.gameId, (newId, oldId) => {
+  if (newId) {
+    fetchItems(newId);
+  } else {
+    items.value = [];
+    isLoading.value = false;
+  }
+});
+
+onUnmounted(() => {
+  if (unsubscribe) {
+    unsubscribe();
+  }
+});
+
+defineExpose({ refresh });
+</script>
+
+<style scoped>
+.box {
+  background-color: #2a2a2a;
+  border-radius: 6px;
+  padding: 1rem;
+}
+.image.is-48x48 {
+  width: 48px;
+  height: 48px;
+}
+.mt-3 {
+  margin-top: 1rem;
+}
+</style>
+

--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -329,9 +329,10 @@ const save = async () => {
         worstShow: 'worstShow' in (localGame.value.custom || {})
           ? (localGame.value.custom as PyramidConfig).worstShow
           : true,
-        communityItems: 'communityItems' in (localGame.value.custom || {})
-          ? (localGame.value.custom as PyramidConfig).communityItems
-          : [],
+        communityItems:
+          'communityItems' in (localGame.value.custom || {})
+            ? (localGame.value.custom as PyramidConfig).communityItems
+            : ((localGame.value as any).communityItems || []),
         communityHeader: 'communityHeader' in (localGame.value.custom || {})
           ? (localGame.value.custom as PyramidConfig).communityHeader
           : undefined,
@@ -350,7 +351,7 @@ const save = async () => {
   }
 
   try {
-    const gameData = {
+    const gameData: any = {
       name: localGame.value.name,
       description: localGame.value.description,
       gameTypeId: props.gameTypeId,
@@ -363,6 +364,9 @@ const save = async () => {
       image: localGame.value.image || '',
       active: localGame.value.active || false,
     };
+    if ((localGame.value as any).communityItems !== undefined) {
+      gameData.communityItems = (localGame.value as any).communityItems;
+    }
     console.log('Saving game to Firestore:', { id: localGame.value.id, data: gameData });
     await setDoc(doc(db, 'games', localGame.value.id), gameData);
     success.value = `Game '${localGame.value.name}' saved successfully`;

--- a/apps/admin/src/views/GameManagement.vue
+++ b/apps/admin/src/views/GameManagement.vue
@@ -15,6 +15,9 @@
         <li v-if="shouldRenderItemList" :class="{ 'is-active': activeTab === 'items' }">
           <a @click="switchTab('items')">Items/Questions</a>
         </li>
+        <li v-if="shouldRenderCommunityItemList" :class="{ 'is-active': activeTab === 'community' }">
+          <a @click="switchTab('community')">Community Items</a>
+        </li>
       </ul>
     </div>
 
@@ -64,6 +67,11 @@
       @cancel="cancelEdit"
       @refresh="refreshItems"
     />
+    <CommunityItemList
+      v-if="activeTab === 'community' && gameTypeCustom === 'PyramidConfig' && selectedGameId"
+      ref="communityItemList"
+      :gameId="selectedGameId"
+    />
     <QuestionList
       v-if="activeTab === 'items' && gameTypeCustom === 'TriviaConfig' && selectedGameId"
       :gameId="selectedGameId"
@@ -91,13 +99,14 @@ import PyramidRowList from '@/components/PyramidRowList.vue';
 import PyramidRowRecord from '@/components/PyramidRowRecord.vue';
 import PyramidItemList from '@/components/PyramidItemList.vue';
 import PyramidItemRecord from '@/components/PyramidItemRecord.vue';
+import CommunityItemList from '@/components/CommunityItemList.vue';
 import QuestionList from '@/components/QuestionList.vue';
 import QuestionRecord from '@/components/QuestionRecord.vue';
 import type { GameType, Game, ConfigType } from '@top-x/shared/types/game';
 import type { PyramidItem, PyramidRow } from '@top-x/shared/types/pyramid';
 import type { TriviaQuestion } from '@top-x/shared/types';
 
-const activeTab = ref<'gameTypes' | 'games' | 'rows' | 'items'>('gameTypes');
+const activeTab = ref<'gameTypes' | 'games' | 'rows' | 'items' | 'community'>('gameTypes');
 const selectedGameTypeId = ref<string | null>(null);
 const selectedGameId = ref<string | null>(null);
 const gameTypeCustom = ref<ConfigType | null>(null);
@@ -108,6 +117,7 @@ const editingItem = ref<PyramidItem | null>(null);
 const editingQuestion = ref<TriviaQuestion | null>(null);
 const pyramidRowList = ref<InstanceType<typeof PyramidRowList> | null>(null);
 const pyramidItemList = ref<InstanceType<typeof PyramidItemList> | null>(null);
+const communityItemList = ref<InstanceType<typeof CommunityItemList> | null>(null);
 
 const shouldRenderRowList = computed(() => {
   const render = selectedGameTypeId.value && selectedGameId.value && gameTypeCustom.value === 'PyramidConfig';
@@ -121,12 +131,20 @@ const shouldRenderItemList = computed(() => {
   return render;
 });
 
+const shouldRenderCommunityItemList = computed(() => {
+  const render = selectedGameTypeId.value && selectedGameId.value && gameTypeCustom.value === 'PyramidConfig';
+  return render;
+});
+
 const switchTab = (tab: typeof activeTab.value) => {
   console.log('switchTab called:', { tab, currentTab: activeTab.value, selectedGameId: selectedGameId.value, gameTypeCustom: gameTypeCustom.value });
   activeTab.value = tab;
   if (tab === 'items' && pyramidItemList.value && selectedGameId.value) {
     console.log('Forcing PyramidItemList refresh on items tab switch');
     pyramidItemList.value.refresh();
+  }
+  if (tab === 'community' && communityItemList.value && selectedGameId.value) {
+    communityItemList.value.refresh();
   }
 };
 
@@ -228,6 +246,12 @@ const refreshItems = () => {
   console.log('refreshItems called');
   if (pyramidItemList.value && selectedGameId.value) {
     pyramidItemList.value.refresh();
+  }
+};
+
+const refreshCommunityItems = () => {
+  if (communityItemList.value && selectedGameId.value) {
+    communityItemList.value.refresh();
   }
 };
 

--- a/apps/client/src/components/PyramidAddItemPopup.vue
+++ b/apps/client/src/components/PyramidAddItemPopup.vue
@@ -145,12 +145,12 @@ async function saveItem() {
       };
       console.log('newItem:', newItem);
 
-      // Save to Firestore communityItems array
+      // Save to Firestore communityItems array under custom configuration
       const gameRef = doc(db, 'games', props.gameId);
       await updateDoc(gameRef, {
-        communityItems: arrayUnion(newItem)
+        'custom.communityItems': arrayUnion(newItem)
       });
-      console.log('PyramidAddItemPopup: Item added to communityItems in Firestore:', newItem);
+      console.log('PyramidAddItemPopup: Item added to custom.communityItems in Firestore:', newItem);
 
       // Emit new item to parent
       emit('add-item', newItem);


### PR DESCRIPTION
## Summary
- preserve communityItems when saving PyramidConfig games
- add CommunityItemList admin component to view/delete community-submitted items
- show Community Items tab in GameManagement
- store new community items under `custom.communityItems` in client popup

## Testing
- `pnpm build:shared` *(fails: Cannot find type definition file)*
- `pnpm build:admin` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_68738ba3de1c832fa4d7839bd6836329