### PR TITLE
Fix PyramidView props and propagate worstShow

### DIFF
--- a/apps/client/src/components/PyramidNav.vue
+++ b/apps/client/src/components/PyramidNav.vue
@@ -45,11 +45,11 @@
         :items="items ?? []"
         :rows="rows ?? []"
         :game-header="gameHeader"
-                :share-image-title="shareImageTitle"
-
+        :share-image-title="shareImageTitle"
         :worst-header="worstHeader"
         :game-title="gameTitle"
         :hide-row-label="hideRowLabel"
+        :worst-show="worstShow"
       />
     </div>
   </div>

--- a/apps/client/src/components/PyramidResults.vue
+++ b/apps/client/src/components/PyramidResults.vue
@@ -17,6 +17,7 @@
           :share-image-title="shareImageTitle"
 
           :hide-row-label="props.hideRowLabel"
+          :worst-show="props.worstShow"
           :user-profile="{ photoURL: vote.photoURL }"
         />
       </div>
@@ -40,6 +41,7 @@ const props = defineProps<{
   gameTitle?: string;
   hideRowLabel?: boolean;
   shareImageTitle?: string;
+  worstShow?: boolean;
 
 }>();
 

--- a/apps/client/src/components/PyramidView.vue
+++ b/apps/client/src/components/PyramidView.vue
@@ -58,7 +58,7 @@
           </div>
         </div>
         <!-- Worst Item -->
-        <div class="worst-item-container">
+        <div class="worst-item-container" v-if="worstShow !== false">
           <h3 class="subtitle has-text-centered has-text-white">{{ worstHeader || 'Worst Item' }}</h3>
           <div class="pyramid-slot box worst-slot dark-slot mx-auto">
             <div v-if="worstItem" class="slot-style">
@@ -128,6 +128,7 @@ const props = defineProps<{
   shareImageTitle?: string;
   shareText?: string;
   shareLink?: string;
+  worstShow?: boolean;
 }>();
 
 const userStore = useUserStore();
@@ -234,7 +235,7 @@ async function preloadImages() {
     }
   });
 
-  if (worstImage.value?.src && !uniqueImageUrls.has(worstImage.value.src)) {
+  if (worstShow !== false && worstImage.value?.src && !uniqueImageUrls.has(worstImage.value.src)) {
     uniqueImageUrls.add(worstImage.value.src);
     imagePromises.push(
       Promise.race([
@@ -263,7 +264,11 @@ async function preloadImages() {
         img.src = preprocessedImages.value.get(img.src)!;
       }
     });
-    if (worstImage.value && preprocessedImages.value.has(worstImage.value.src)) {
+    if (
+      worstShow !== false &&
+      worstImage.value &&
+      preprocessedImages.value.has(worstImage.value.src)
+    ) {
       worstImage.value.src = preprocessedImages.value.get(worstImage.value.src)!;
     }
     isImageLoading.value = false;


### PR DESCRIPTION
## Summary
- add `worstShow` prop to `PyramidView`
- conditionally render worst slot and handle images when hidden
- forward `worstShow` from `PyramidNav` to `PyramidResults`
- allow `PyramidResults` and `PyramidView` to accept the `worstShow` prop

## Testing
- `pnpm build:client` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687392e39ee0832fbabcba676db1b75c