### PR TITLE
Enhance analytics logging

### DIFF
--- a/apps/client/src/components/NavBar.vue
+++ b/apps/client/src/components/NavBar.vue
@@ -68,6 +68,7 @@ import { useUserStore } from '@/stores/user';
 import { useRouter } from 'vue-router';
 import { computed, ref } from 'vue';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
+import { analytics, trackEvent } from '@top-x/shared';
 
 const userStore = useUserStore();
 const router = useRouter();
@@ -82,9 +83,11 @@ const error = computed(() => userStore.error);
 
 const handleLogin = async () => {
   console.log('Initiating login with X');
+  trackEvent(analytics, 'user_action', { action: 'login_click', context: 'nav' });
   await userStore.loginWithX();
   if (userStore.user && userStore.profile) {
     console.log('Login successful, redirecting to /profile');
+    trackEvent(analytics, 'user_action', { action: 'login', method: 'x_auth', context: 'nav' });
     // router.push('/profile');
     isMenuActive.value = false;
   } else {
@@ -95,6 +98,7 @@ const handleLogin = async () => {
 const logout = async () => {
   console.log('Initiating logout');
   await userStore.logout();
+  trackEvent(analytics, 'user_action', { action: 'logout' });
   router.push('/');
   isMenuActive.value = false;
 };

--- a/apps/client/src/router/index.ts
+++ b/apps/client/src/router/index.ts
@@ -94,14 +94,21 @@ router.beforeEach((to, from, next) => {
   }
 });
 
-router.afterEach((to) => {
+router.afterEach((to, from) => {
   if (analytics) {
+    const userStore = useUserStore();
     const game = to.query.game || 'unknown';
+    logEvent(analytics, 'navigation', {
+      from_path: from.fullPath,
+      to_path: to.fullPath,
+      logged_in: !!userStore.user,
+      game_id: game,
+    });
     logEvent(analytics, 'page_view_public', {
       page_path: to.path,
       page_search: to.fullPath.split('?')[1] || '',
       page_title: document.title || to.name,
-      game_id: game,  // Added for game-specific tracking
+      game_id: game,
     });
   }
 });

--- a/apps/client/src/stores/user.ts
+++ b/apps/client/src/stores/user.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, watch } from 'vue';
-import { auth, db, functions } from '@top-x/shared';
+import { auth, db, functions, analytics, trackEvent } from '@top-x/shared';
 import { signInWithPopup, TwitterAuthProvider, onAuthStateChanged, User as FirebaseUser } from 'firebase/auth';
 import { doc, onSnapshot, setDoc, updateDoc, arrayUnion, arrayRemove, getDoc } from 'firebase/firestore';
 import { httpsCallable, HttpsCallable } from 'firebase/functions';
@@ -208,6 +208,7 @@ export const useUserStore = defineStore('user', () => {
           addedBy: arrayUnion(user.value.uid),
         });
         console.log(`Successfully updated frenemy ${frenemyUid} addedBy with ${user.value.uid}`);
+        trackEvent(analytics, 'user_action', { action: 'add_frenemy', frenemy_uid: frenemyUid });
       } catch (err: any) {
         console.error('Error updating frenemy addedBy:', {
           userId: user.value.uid,
@@ -247,6 +248,7 @@ export const useUserStore = defineStore('user', () => {
         addedBy: arrayRemove(user.value.uid),
       });
       console.log(`Removed frenemy ${frenemyUid} for user ${user.value.uid}`);
+      trackEvent(analytics, 'user_action', { action: 'remove_frenemy', frenemy_uid: frenemyUid });
     } catch (err: any) {
       console.error('Error removing frenemy:', err);
       error.value = err.message;

--- a/apps/client/src/views/Home.vue
+++ b/apps/client/src/views/Home.vue
@@ -47,6 +47,7 @@ import { db } from '@top-x/shared';
 import Card from '@top-x/shared/components/Card.vue';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
 import fallbackImg from '@/assets/images/fallback.png';
+import { analytics, trackEvent } from '@top-x/shared';
 
 const router = useRouter();
 
@@ -77,8 +78,9 @@ useHead({
 
 onMounted(() => {
   console.log('Home: Fetching games from Firestore...');
-    const q = query(collection(db, 'games'));
-    onSnapshot(q, (snapshot) => {
+  trackEvent(analytics, 'page_view', { page_name: 'home' });
+  const q = query(collection(db, 'games'));
+  onSnapshot(q, (snapshot) => {
     games.value = snapshot.docs.map((doc) => {
       const data = doc.data();
       console.log('Home: Game fetched:', { id: doc.id, data });
@@ -102,6 +104,9 @@ onMounted(() => {
 });
 
 function navigateToGame(route: string) {
+  const idMatch = route.match(/game=([^&]+)/);
+  const gameId = idMatch ? idMatch[1] : 'unknown';
+  trackEvent(analytics, 'select_game', { game_id: gameId });
   router.push(route);
 }
 </script>

--- a/apps/client/src/views/Profile.vue
+++ b/apps/client/src/views/Profile.vue
@@ -89,6 +89,7 @@ import Leaderboard from '@/components/Leaderboard.vue';
 import Card from '@top-x/shared/components/Card.vue';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
 import type { User, UserGameData } from '@top-x/shared/types/user';
+import { analytics, trackEvent } from '@top-x/shared';
 
 interface LeaderboardEntry {
   uid: string;
@@ -204,6 +205,7 @@ function closeLoginTab() {
 }
 
 onMounted(() => {
+  trackEvent(analytics, 'page_view', { page_name: 'profile' });
   if (isLoggedIn.value) {
     fetchFrenemies();
     fetchAddedBy();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,3 +34,4 @@ const db = getFirestore(app);
 const functions = getFunctions(app);
 
 export { app, auth, db, functions, analytics, storage };
+export * from './utils/analytics';

--- a/packages/shared/src/utils/analytics.ts
+++ b/packages/shared/src/utils/analytics.ts
@@ -1,0 +1,15 @@
+import { Analytics, logEvent } from 'firebase/analytics';
+
+export function trackEvent(
+  analytics: Analytics | null | undefined,
+  eventName: string,
+  params: Record<string, any> = {}
+) {
+  try {
+    if (analytics) {
+      logEvent(analytics, eventName, params);
+    }
+  } catch (err) {
+    console.error('Analytics error:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- wrap Firebase logEvent in new helper
- track navigation in the router
- capture login/logout analytics
- log game selections on the Home page
- record profile page views
- report friend actions to analytics

## Testing
- `npm run --silent build --workspace=packages/shared` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_687db8083454832fb8ac3a0cfb674e15