### PR TITLE
Support viewing others' profile

### DIFF
--- a/apps/client/src/components/Leaderboard.vue
+++ b/apps/client/src/components/Leaderboard.vue
@@ -59,14 +59,7 @@
 
 <script setup lang="ts">
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
-
-interface LeaderboardEntry {
-  uid: string;
-  displayName: string;
-  username: string;
-  photoURL: string;
-  score: number;
-}
+import type { LeaderboardEntry } from '@top-x/shared/types/game';
 
 defineProps<{
   title: string;

--- a/apps/client/src/services/trivia.ts
+++ b/apps/client/src/services/trivia.ts
@@ -1,13 +1,7 @@
 // Helper functions for calling trivia-related Cloud Functions
-const FUNCTION_BASE_URL = 'u6yhyetroa-uc.a.run.app';
+import type { LeaderboardEntry } from '@top-x/shared/types/game';
 
-interface LeaderboardEntry {
-  uid: string;
-  displayName: string;
-  username: string;
-  photoURL: string;
-  score: number;
-}
+const FUNCTION_BASE_URL = 'u6yhyetroa-uc.a.run.app';
 
 async function fetchJson<T>(url: string): Promise<T> {
   console.log('Fetching:', url);


### PR DESCRIPTION
## Summary
- allow viewing other user's profile via `?user=` query
- display pyramid data from user game data
- use shared `LeaderboardEntry` type across the app

## Testing
- `npm run build:shared` *(fails: Cannot find type definition file for 'node')*
- `npm run build:client` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687ddf9cd314832fb00bf2118719afc8