### PR TITLE
Add ZoneBreaker admin defaults

### DIFF
--- a/apps/client/src/router/index.ts
+++ b/apps/client/src/router/index.ts
@@ -10,6 +10,7 @@ import FAQ from '@/views/FAQ.vue';
 import Trivia from '@/views/games/Trivia.vue';
 import PyramidTier from '@/views/games/PyramidTier.vue';
 import TerritoryCapture from '@/views/games/TerritoryCapture.vue';
+import ZoneBreaker from '@/views/games/ZoneBreaker.vue';
 
 import FrenemySearch from '@/views/FrenemySearch.vue';
 import { useUserStore } from '../stores/user';
@@ -56,6 +57,11 @@ const routes = [
     path: '/games/TerritoryCapture',
     name: 'TerritoryCapture',
     component: TerritoryCapture,
+  },
+  {
+    path: '/games/ZoneBreaker',
+    name: 'ZoneBreaker',
+    component: ZoneBreaker,
   },
   {
     path: '/games/PyramidTier',

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -27,7 +27,7 @@ export interface Game {
   shareLink?: string;
   image: string;
   vip: string[];
-  custom: PyramidConfig | TriviaConfig | TerritoryCaptureConfig; // Union of possible config types
+  custom: PyramidConfig | TriviaConfig | TerritoryCaptureConfig | ZoneBreakerConfig; // Union of possible config types
 }
 
 export interface LeaderboardEntry {


### PR DESCRIPTION
## Summary
- support `ZoneBreakerConfig` in shared Game type
- add ZoneBreaker config editor and defaults to admin
- register ZoneBreaker route in client

## Testing
- `npm run build --workspaces --if-present` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fa35f30e8832f85edfd83484ea06d