### PR TITLE
Add player assets to ZoneBreaker admin config

### DIFF
--- a/apps/admin/src/components/GameRecord.vue
+++ b/apps/admin/src/components/GameRecord.vue
@@ -242,19 +242,31 @@
         </div>
       </div>
     </div>
-    <div v-if="gameTypeCustom === 'ZoneBreakerConfig'">
-      <h3 class="subtitle has-text-white">ZoneBreaker Config</h3>
-      <div class="field">
-        <label class="label has-text-white">Levels JSON</label>
-        <div class="control">
-          <textarea v-model="zoneLevelsText" class="textarea"></textarea>
+      <div v-if="gameTypeCustom === 'ZoneBreakerConfig'">
+        <h3 class="subtitle has-text-white">ZoneBreaker Config</h3>
+        <div class="field">
+          <label class="label has-text-white">Levels JSON</label>
+          <div class="control">
+            <textarea v-model="zoneLevelsText" class="textarea"></textarea>
+          </div>
         </div>
-      </div>
-      <div class="field">
-        <label class="label has-text-white">Win Percentage</label>
-        <div class="control">
-          <input v-model.number="(localGame.custom as any).winPercentage" class="input" type="number" />
+        <div class="field">
+          <label class="label has-text-white">Player Asset URL</label>
+          <div class="control">
+            <input v-model="(localGame.custom as any).playerAsset" class="input" type="text" />
+          </div>
         </div>
+        <div class="field">
+          <label class="label has-text-white">Player Scale</label>
+          <div class="control">
+            <input v-model.number="(localGame.custom as any).playerScale" class="input" type="number" />
+          </div>
+        </div>
+        <div class="field">
+          <label class="label has-text-white">Win Percentage</label>
+          <div class="control">
+            <input v-model.number="(localGame.custom as any).winPercentage" class="input" type="number" />
+          </div>
       </div>
       <div class="field">
         <label class="label has-text-white">Player Speed</label>
@@ -640,6 +652,11 @@ const save = async () => {
     }
     customData = {
       levels,
+      playerAsset: (localGame.value.custom as any).playerAsset || '',
+      playerScale:
+        (localGame.value.custom as any).playerScale !== undefined
+          ? Number((localGame.value.custom as any).playerScale)
+          : undefined,
       winPercentage: Number((localGame.value.custom as any).winPercentage) || 0,
       playerSpeed: Number((localGame.value.custom as any).playerSpeed) || 0,
       enemySpeed: Number((localGame.value.custom as any).enemySpeed) || 0,

--- a/packages/shared/src/types/zoneBreaker.ts
+++ b/packages/shared/src/types/zoneBreaker.ts
@@ -1,4 +1,8 @@
 export interface ZoneBreakerConfig {
+  /** Sprite asset for the player */
+  playerAsset: string;
+  /** Optional scale for the player sprite */
+  playerScale?: number;
   levels: LevelConfig[]; // Array of levels for Arcade mode
   winPercentage: number; // Default 75
   playerSpeed: number;


### PR DESCRIPTION
## Summary
- extend `ZoneBreakerConfig` with `playerAsset` and `playerScale`
- expose new player fields in admin form
- save the fields when creating `ZoneBreakerConfig`

## Testing
- `npm run build:shared` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_68809f3fc24c832f9515e5ccd13fffd9