### PR TITLE
Add ZoneRevealConfig and update VolfiedScene

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -48,6 +48,10 @@
     "./types/zoneBreaker": {
       "types": "./src/types/zoneBreaker.ts",
       "default": "./src/types/zoneBreaker.ts"
+    },
+    "./types/zoneReveal": {
+      "types": "./src/types/zoneReveal.ts",
+      "default": "./src/types/zoneReveal.ts"
     }
   }
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './trivia';
 export * from './game';
 export * from './territoryCapture';
 export * from './zoneBreaker';
+export * from './zoneReveal';

--- a/packages/shared/src/types/zoneReveal.ts
+++ b/packages/shared/src/types/zoneReveal.ts
@@ -1,0 +1,27 @@
+export interface EnemyConfig {
+  type: string;
+  count: number;
+}
+
+export interface PowerupConfig {
+  type: string;
+  count: number;
+}
+
+export interface LevelConfig {
+  enemyConfig: EnemyConfig[];
+  powerupConfig: PowerupConfig[];
+  timeLimit: number;
+  hiddenImage: string;
+  levelHeader: string;
+}
+
+export interface ZoneRevealConfig {
+  levelsConfig: LevelConfig[];
+  backgroundImage?: string;
+  spritesheets?: Record<string, string>;
+  playerSpeed?: number;
+  enemiesSpeedArray?: Record<string, number>;
+  finishPercent?: number;
+  heartIcon?: string;
+}


### PR DESCRIPTION
## Summary
- introduce new `ZoneRevealConfig` type for zone reveal game settings
- export it from shared types and add package export
- update `VolfiedScene` to use the new config and support multiple enemy types
- make player speed, enemy speed and finish percent configurable

## Testing
- `npm run build:shared` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_b_688b25129194832fb857991421a353cc