### PR TITLE
fix ts paths for shared types

### DIFF
--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -17,7 +17,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@top-x/shared": ["../../packages/shared/src/index.ts"],
-      "@top-x/shared/*": ["../../packages/shared/src/*"]
+      "@top-x/shared/*": ["../../packages/shared/src/*"],
+      "@top-x/shared/types/*": ["../../packages/shared/src/types/*"]
     },
     "types": ["vite/client", "node"]
   },

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@top-x/shared': path.resolve(__dirname, '../../packages/shared/src'),
+      '@top-x/shared/types': path.resolve(__dirname, '../../packages/shared/src/types'),
     },
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
   },

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -17,7 +17,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@top-x/shared": ["../../packages/shared/src/index.ts"],
-      "@top-x/shared/*": ["../../packages/shared/src/*"]
+      "@top-x/shared/*": ["../../packages/shared/src/*"],
+      "@top-x/shared/types/*": ["../../packages/shared/src/types/*"]
     },
     "types": ["vite/client", "node"]
   },

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@top-x/shared': path.resolve(__dirname, '../../packages/shared/src'),
+      '@top-x/shared/types': path.resolve(__dirname, '../../packages/shared/src/types'),
     },
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
   },

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "es2017",
     "esModuleInterop": true,
     "paths": {
-      "@top-x/shared/*": ["../packages/shared/src/*"]
+      "@top-x/shared/*": ["../packages/shared/src/*"],
+      "@top-x/shared/types/*": ["../packages/shared/src/types/*"]
     }
   },
   "compileOnSave": true,


### PR DESCRIPTION
## Summary
- expose `@top-x/shared/types/*` alias in tsconfig and Vite
- allow functions to resolve shared types

## Testing
- `npx tsc -p apps/client/tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'node', etc.)*
- `npm run build:client` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b389d1e24832f85400ce5c03cee56