### PR TITLE
Load zone reveal config dynamically

### DIFF
--- a/apps/admin/src/types/zoneReveal.ts
+++ b/apps/admin/src/types/zoneReveal.ts
@@ -1,0 +1,39 @@
+export interface EnemyConfig {
+  type: string;
+  count: number;
+}
+
+export interface PowerupConfig {
+  type: string;
+  count: number;
+}
+
+export interface LevelConfig {
+  enemyConfig: EnemyConfig[];
+  powerupConfig: PowerupConfig[];
+  timeLimit: number;
+  hiddenImage: string;
+  levelHeader: string;
+}
+
+export interface ZoneRevealConfig {
+  levelsConfig: LevelConfig[];
+  backgroundImage?: string;
+  spritesheets?: Record<string, string>;
+  playerSpeed?: number;
+  enemiesSpeedArray?: Record<string, number>;
+  finishPercent?: number;
+  heartIcon?: string;
+}
+
+// interface EnemyType {
+//   type: 'core' | 'chaser' | 'zigzag' | 'bouncer' | 'projectile' | 'bomb';
+//   asset: string;
+//   speed: number;
+//   behavior: 'roam' | 'borderChase' | 'zigzag' | 'bounce' | 'shoot' | 'explode';
+// }
+
+// interface PowerUp {
+//   type: 'speed' | 'shield' | 'freeze' | 'bomb';
+//   asset: string;
+// }

--- a/apps/client/src/components/games/ZoneRevealScene.ts
+++ b/apps/client/src/components/games/ZoneRevealScene.ts
@@ -10,55 +10,25 @@ const GRID_W = WIDTH / TILE_SIZE;
 const GRID_H = HEIGHT / TILE_SIZE;
 const PLAYER_VISUAL_SIZE = 30;
 
-export default class VolfiedScene extends Phaser.Scene {
-  private player!: Phaser.GameObjects.Sprite;
-  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-  private direction: 'up' | 'down' | 'left' | 'right' | null = null;
-  private trail: { x: number; y: number }[] = [];
-  private fillMask: number[][] = [];
-  private filledTiles = 0;
-  private lives = 3;
-  private score = 0;
-  private timeLimit = 60;
-  private remainingTime = 60;
-  private totalTime = 0;
-  private isLosingLife = false;
-  private currentLevel = 0;
-  private levels: LevelConfig[] = [];
-  private levelText!: Phaser.GameObjects.Text;
-  private filledText!: Phaser.GameObjects.Text;
-  private livesIcons: Phaser.GameObjects.Image[] = [];
-  private scoreText!: Phaser.GameObjects.Text;
-  private remainingTimeText!: Phaser.GameObjects.Text;
-  private totalTimeText!: Phaser.GameObjects.Text;
-  private revealMask!: Phaser.GameObjects.Graphics;
-  private trailGraphics!: Phaser.GameObjects.Graphics;
-  private borderGraphics!: Phaser.GameObjects.Graphics;
-  private smokeEmitter!: Phaser.GameObjects.Particles.ParticleEmitter;
-  private enemyGroup!: Phaser.Physics.Arcade.Group;
-  private powerupGroup!: Phaser.Physics.Arcade.Group;
-  private hiddenImage!: Phaser.GameObjects.Image;
-
-  // Config for levels
-  private zoneRevealConfig: ZoneRevealConfig = {
-    backgroundImage: '/assets/anonymous.png',
-    spritesheets: {
-      player: '/assets/Monocle_spritesheet.png',
-      enemy: '/assets/monster_spritesheet.png',
-      robot: '/assets/robot_spritesheet.png',
-      heart: '/assets/heart_spritesheet.png',
-      clock: '/assets/time_spritesheet.png'
-    },
-    playerSpeed: 100,
-    enemiesSpeedArray: { bouncing: 100, robot: 80 },
-    finishPercent: 80,
-    heartIcon: '/assets/heart_icon.png',
-    levelsConfig: [
-      {
-        enemyConfig: [
-          { type: 'bouncing', count: 0 },
-          { type: 'robot', count: 0 }
-        ],
+const DEFAULT_ZONE_REVEAL_CONFIG: ZoneRevealConfig = {
+  backgroundImage: '/assets/anonymous.png',
+  spritesheets: {
+    player: '/assets/Monocle_spritesheet.png',
+    enemy: '/assets/monster_spritesheet.png',
+    robot: '/assets/robot_spritesheet.png',
+    heart: '/assets/heart_spritesheet.png',
+    clock: '/assets/time_spritesheet.png'
+  },
+  playerSpeed: 100,
+  enemiesSpeedArray: { bouncing: 100, robot: 80 },
+  finishPercent: 80,
+  heartIcon: '/assets/heart_icon.png',
+  levelsConfig: [
+    {
+      enemyConfig: [
+        { type: 'bouncing', count: 0 },
+        { type: 'robot', count: 0 }
+      ],
       powerupConfig: [
         { type: 'extralive', count: 3 },
         { type: 'extratime', count: 3 }
@@ -67,7 +37,7 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/levels/level1.jpeg',
       levelHeader: 'Level 1'
     },
-     {
+    {
       enemyConfig: [
         { type: 'bouncing', count: 0 },
         { type: 'robot', count: 0 }
@@ -80,7 +50,7 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/levels/level2.jpeg',
       levelHeader: 'Level 2'
     },
-     {
+    {
       enemyConfig: [
         { type: 'bouncing', count: 0 },
         { type: 'robot', count: 0 }
@@ -93,7 +63,7 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/levels/level3.jpeg',
       levelHeader: 'Level 3'
     },
-     {
+    {
       enemyConfig: [
         { type: 'bouncing', count: 0 },
         { type: 'robot', count: 0 }
@@ -106,7 +76,7 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/levels/level4.jpeg',
       levelHeader: 'Level 4'
     },
-     {
+    {
       enemyConfig: [
         { type: 'bouncing', count: 0 },
         { type: 'robot', count: 0 }
@@ -119,7 +89,7 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/levels/level5.jpeg',
       levelHeader: 'Level 5'
     },
-     {
+    {
       enemyConfig: [
         { type: 'bouncing', count: 0 },
         { type: 'robot', count: 0 }
@@ -132,7 +102,7 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/levels/level6.jpeg',
       levelHeader: 'Level 6'
     },
-     {
+    {
       enemyConfig: [
         { type: 'bouncing', count: 0 },
         { type: 'robot', count: 0 }
@@ -145,7 +115,7 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/levels/level7.jpeg',
       levelHeader: 'Level 7'
     },
-     {
+    {
       enemyConfig: [
         { type: 'bouncing', count: 0 },
         { type: 'robot', count: 0 }
@@ -184,11 +154,44 @@ export default class VolfiedScene extends Phaser.Scene {
       hiddenImage: '/assets/magal.png',
       levelHeader: 'Boss Level'
     }
-    ]
-  };
+  ]
+};
 
-  constructor() {
+export default class VolfiedScene extends Phaser.Scene {
+  private player!: Phaser.GameObjects.Sprite;
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+  private direction: 'up' | 'down' | 'left' | 'right' | null = null;
+  private trail: { x: number; y: number }[] = [];
+  private fillMask: number[][] = [];
+  private filledTiles = 0;
+  private lives = 3;
+  private score = 0;
+  private timeLimit = 60;
+  private remainingTime = 60;
+  private totalTime = 0;
+  private isLosingLife = false;
+  private currentLevel = 0;
+  private levels: LevelConfig[] = [];
+  private levelText!: Phaser.GameObjects.Text;
+  private filledText!: Phaser.GameObjects.Text;
+  private livesIcons: Phaser.GameObjects.Image[] = [];
+  private scoreText!: Phaser.GameObjects.Text;
+  private remainingTimeText!: Phaser.GameObjects.Text;
+  private totalTimeText!: Phaser.GameObjects.Text;
+  private revealMask!: Phaser.GameObjects.Graphics;
+  private trailGraphics!: Phaser.GameObjects.Graphics;
+  private borderGraphics!: Phaser.GameObjects.Graphics;
+  private smokeEmitter!: Phaser.GameObjects.Particles.ParticleEmitter;
+  private enemyGroup!: Phaser.Physics.Arcade.Group;
+  private powerupGroup!: Phaser.Physics.Arcade.Group;
+  private hiddenImage!: Phaser.GameObjects.Image;
+
+  // Config for levels
+  private zoneRevealConfig: ZoneRevealConfig;
+
+  constructor(config?: ZoneRevealConfig) {
     super('GameScene');
+    this.zoneRevealConfig = config || DEFAULT_ZONE_REVEAL_CONFIG;
     this.levels = this.zoneRevealConfig.levelsConfig;
     this.remainingTime = this.levels.length > 0 ? this.levels[0].timeLimit : 60;
   }


### PR DESCRIPTION
## Summary
- pass `ZoneRevealConfig` into the Phaser scene
- fetch config in `ZoneReveal.vue`
- copy `zoneReveal` types to admin for convenience

## Testing
- `npm run build:client` *(fails: vite not found)*
- `npm run build:admin` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b517c9e68832f83a09e23648c3030