### PR TITLE
fix: persist zone reveal custom objects

### DIFF
--- a/apps/client/src/components/BuildAddNewGame.vue
+++ b/apps/client/src/components/BuildAddNewGame.vue
@@ -139,7 +139,7 @@ const game = ref<Game>(props.existingGame ? { ...props.existingGame } : {
   shareLink: '',
 });
 
-function getDefaultCustom(customType: string): PyramidConfig  | ZoneRevealConfig {
+function getDefaultCustom(customType: string): PyramidConfig | ZoneRevealConfig {
   if (customType === 'PyramidConfig') {
     return {
       items: [],
@@ -154,7 +154,7 @@ function getDefaultCustom(customType: string): PyramidConfig  | ZoneRevealConfig
       communityItems: [],
       communityHeader: '',
     };
-  } else if (customType === 'zoneRevealConfig') {
+  } else if (customType === 'ZoneRevealConfig') {
     return {
       levelsConfig: [],
       backgroundImage: '',
@@ -164,7 +164,6 @@ function getDefaultCustom(customType: string): PyramidConfig  | ZoneRevealConfig
       finishPercent: 0,
       heartIcon: '',
     };
-  
   } else {
     throw new Error('Unknown custom type');
   }
@@ -172,7 +171,7 @@ function getDefaultCustom(customType: string): PyramidConfig  | ZoneRevealConfig
 
 async function saveGame() {
   try {
-    const data = { ...game.value };
+    const data = JSON.parse(JSON.stringify(game.value));
     delete data.id;
     if (props.existingGame && props.existingGame.id) {
       const gameRef = doc(db, 'games', props.existingGame.id);

--- a/apps/client/src/components/build/AddZoneReveal.vue
+++ b/apps/client/src/components/build/AddZoneReveal.vue
@@ -187,8 +187,21 @@ const newSpriteValue = ref('');
 const newEnemyKey = ref('');
 const newEnemyValue = ref(0);
 
-watch(() => props.modelValue, (val) => { config.value = val; }, { deep: true });
-watch(config, (val) => { emit('update:modelValue', val); }, { deep: true });
+watch(
+  () => props.modelValue,
+  (val) => {
+    // Clone to avoid keeping Vue proxies in the parent
+    config.value = JSON.parse(JSON.stringify(val));
+  },
+  { deep: true, immediate: true }
+);
+watch(
+  config,
+  (val) => {
+    emit('update:modelValue', JSON.parse(JSON.stringify(val)));
+  },
+  { deep: true }
+);
 
 function addLevel() {
   config.value.levelsConfig.push({


### PR DESCRIPTION
## Summary
- ensure default ZoneRevealConfig is generated correctly
- clone game data before saving so nested custom fields persist
- send plain objects from ZoneReveal builder to keep spritesheet and enemy speed maps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build --workspace=apps/client`


------
https://chatgpt.com/codex/tasks/task_b_6890ff4b8bf8832fa9eba4406d4c6da0