### PR TITLE
feat: add daily challenge editing

### DIFF
--- a/apps/client/src/components/build/AddDailyChallenge.vue
+++ b/apps/client/src/components/build/AddDailyChallenge.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="box mt-4">
+    <h3 class="title is-4 has-text-white">{{ challenge.date ? 'Edit' : 'Add' }} Daily Challenge</h3>
+    <div class="field">
+      <label class="label has-text-white">Number</label>
+      <input class="input" type="number" v-model.number="localChallenge.number" />
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Date</label>
+      <input class="input" type="date" v-model="localChallenge.date" />
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Challenge Available UTC</label>
+      <input class="input" type="datetime-local" v-model="localChallenge.challengeAvailableUTC" />
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Answer Reveal UTC</label>
+      <input class="input" type="datetime-local" v-model="localChallenge.answerRevealUTC" />
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Next Challenge Announce UTC</label>
+      <input class="input" type="datetime-local" v-model="localChallenge.nextChallengeAnnounceUTC" />
+    </div>
+    <div class="field">
+      <label class="checkbox has-text-white">
+        <input type="checkbox" v-model="localChallenge.showCountdown" />
+        Show Countdown
+      </label>
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Difficulty</label>
+      <div class="select">
+        <select v-model="localChallenge.difficulty">
+          <option value="" disabled>Select difficulty</option>
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
+      </div>
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Category</label>
+      <input class="input" v-model="localChallenge.category" />
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Share Text</label>
+      <input class="input" v-model="localChallenge.shareText" />
+    </div>
+    <div class="field">
+      <label class="label has-text-white">Discussion URL</label>
+      <input class="input" v-model="localChallenge.discussionUrl" />
+    </div>
+    <div class="buttons mt-3">
+      <CustomButton type="is-success" label="Save" @click="save" />
+      <CustomButton type="is-light" label="Cancel" @click="emit('cancel')" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { doc, setDoc } from 'firebase/firestore';
+import { db } from '@top-x/shared';
+import CustomButton from '@top-x/shared/components/CustomButton.vue';
+import type { Game } from '@top-x/shared/types/game';
+import type { DailyChallenge } from '@top-x/shared/types/dailyChallenge';
+
+const props = defineProps<{ game: Game; challenge: DailyChallenge }>();
+const emit = defineEmits<{ (e: 'saved'): void; (e: 'cancel'): void }>();
+
+const localChallenge = ref<DailyChallenge>({ ...props.challenge });
+
+async function save() {
+  const challengeRef = doc(db, 'games', props.game.id, 'daily_challenges', localChallenge.value.date);
+  await setDoc(challengeRef, {
+    ...localChallenge.value,
+    custom: props.game.custom,
+    createdAt: localChallenge.value.createdAt || new Date().toISOString(),
+  });
+  emit('saved');
+}
+</script>
+
+<style scoped>
+.box {
+  background: #222;
+}
+</style>

--- a/apps/client/src/components/build/DailyChallengesList.vue
+++ b/apps/client/src/components/build/DailyChallengesList.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="daily-challenges-list">
+    <h3 class="title is-4 has-text-white">Daily Challenges for {{ game.name }}</h3>
+    <CustomButton type="is-success" label="Add Challenge" @click="addChallenge" />
+    <table class="table is-fullwidth has-text-white mt-3">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Number</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="challenge in challenges" :key="challenge.id">
+          <td>{{ challenge.date }}</td>
+          <td>{{ challenge.number }}</td>
+          <td>
+            <CustomButton type="is-small is-info" label="Edit" @click="editChallenge(challenge)" />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <AddDailyChallenge
+      v-if="editingChallenge"
+      :game="game"
+      :challenge="editingChallenge"
+      @saved="closeEditor"
+      @cancel="closeEditor"
+    />
+    <div class="mt-3">
+      <CustomButton type="is-light" label="Close" @click="emit('close')" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '@top-x/shared';
+import CustomButton from '@top-x/shared/components/CustomButton.vue';
+import AddDailyChallenge from './AddDailyChallenge.vue';
+import type { Game } from '@top-x/shared/types/game';
+import type { DailyChallenge } from '@top-x/shared/types/dailyChallenge';
+
+const props = defineProps<{ game: Game }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const challenges = ref<(DailyChallenge & { id: string })[]>([]);
+const editingChallenge = ref<DailyChallenge | null>(null);
+let unsubscribe: (() => void) | null = null;
+
+onMounted(() => {
+  const colRef = collection(db, 'games', props.game.id, 'daily_challenges');
+  unsubscribe = onSnapshot(colRef, snapshot => {
+    challenges.value = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as DailyChallenge) }));
+  });
+});
+
+onUnmounted(() => {
+  if (unsubscribe) unsubscribe();
+});
+
+function addChallenge() {
+  editingChallenge.value = {
+    number: challenges.value.length + 1,
+    date: '',
+    createdAt: new Date().toISOString(),
+    challengeAvailableUTC: '',
+    answerRevealUTC: '',
+    nextChallengeAnnounceUTC: '',
+    custom: props.game.custom,
+  };
+}
+
+function editChallenge(ch: DailyChallenge & { id: string }) {
+  editingChallenge.value = { ...ch };
+}
+
+function closeEditor() {
+  editingChallenge.value = null;
+}
+</script>
+
+<style scoped>
+.daily-challenges-list {
+  padding: 1rem;
+}
+</style>

--- a/apps/client/src/views/Build.vue
+++ b/apps/client/src/views/Build.vue
@@ -39,6 +39,11 @@
                   :label="game.active ? 'Unpublish' : 'Publish'"
                   @click="togglePublish(game)"
                 />
+                <CustomButton
+                  type="is-info"
+                  label="Edit Daily Challenges"
+                  @click="openDailyChallenges(game)"
+                />
               </div>
             </div>
           </Card>
@@ -54,6 +59,11 @@
           @cancel="handleCancel"
         />
       </div>
+      <DailyChallengesList
+        v-if="selectedDailyChallengesGame"
+        :game="selectedDailyChallengesGame"
+        @close="selectedDailyChallengesGame = null"
+      />
     </div>
   </div>
 </template>
@@ -66,6 +76,7 @@ import { db } from '@top-x/shared';
 import Card from '@top-x/shared/components/Card.vue';
 import CustomButton from '@top-x/shared/components/CustomButton.vue';
 import BuildAddNewGame from '@/components/BuildAddNewGame.vue';
+import DailyChallengesList from '@/components/build/DailyChallengesList.vue';
 import type { GameType, Game } from '@top-x/shared/types/game';
 
 const userStore = useUserStore();
@@ -74,6 +85,7 @@ const availableGameTypes = ref<GameType[]>([]);
 const myGames = ref<Game[]>([]);
 const selectedGameType = ref<GameType | null>(null);
 const selectedGame = ref<Game | null>(null);
+const selectedDailyChallengesGame = ref<Game | null>(null);
 
 onMounted(() => {
   if (user.value) {
@@ -114,6 +126,10 @@ function editGame(game: Game) {
   } else {
     console.error('Game type not found for editing');
   }
+}
+
+function openDailyChallenges(game: Game) {
+  selectedDailyChallengesGame.value = game;
 }
 
 async function togglePublish(game: Game) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,6 +49,10 @@
     "./types/zoneReveal": {
       "types": "./src/types/zoneReveal.ts",
       "default": "./src/types/zoneReveal.ts"
+    },
+    "./types/dailyChallenge": {
+      "types": "./src/types/dailyChallenge.ts",
+      "default": "./src/types/dailyChallenge.ts"
     }
   }
 }

--- a/packages/shared/src/types/dailyChallenge.ts
+++ b/packages/shared/src/types/dailyChallenge.ts
@@ -1,0 +1,34 @@
+import { PyramidConfig } from './pyramid';
+import { TriviaConfig } from './trivia';
+import { ZoneRevealConfig } from './zoneReveal';
+
+export interface DailyChallenge {
+  // Meta
+  number: number;             // Sequential challenge number (e.g. 183)
+  date: string;               // "YYYY-MM-DD" — the logical date of the challenge
+  createdAt: string;          // ISO timestamp — when the challenge was created/uploaded
+  challengeAvailableUTC: string; // ISO timestamp — when the level becomes available to play
+  answerRevealUTC: string;    // ISO timestamp — when the answer is revealed
+  nextChallengeAnnounceUTC: string; // ISO timestamp — when next challenge is promoted (optional)
+
+  // Game content
+  custom: PyramidConfig | TriviaConfig | ZoneRevealConfig; // Union of possible config types
+
+  // Optional display settings
+  showCountdown?: boolean;   // Whether to show time until reveal
+  difficulty?: 'easy' | 'medium' | 'hard';
+  category?: string;         // e.g., "logic", "visual", "history", etc.
+
+  // Social & marketing
+  shareText?: string;        // Suggested post: "Today's riddle is 🔥!"
+  discussionUrl?: string;    // Link to share/discuss the level
+
+  // Analytics (write/update later via backend or Cloud Functions)
+  totalAttempts?: number;
+  correctAttempts?: number;
+  averageSolveTimeSec?: number;
+
+  // Flags (optional)
+  isArchived?: boolean;      // For cleanup or migration
+  isFeatured?: boolean;      // For editor's picks or replay promotion
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './pyramid';
 export * from './trivia';
 export * from './game';
 export * from './zoneReveal';
+export * from './dailyChallenge';


### PR DESCRIPTION
## Summary
- define DailyChallenge type in shared package
- add management UI for game daily challenges
- wire button on Build view to edit daily challenges

## Testing
- `npm run build:shared`
- `npm run build:client`


------
https://chatgpt.com/codex/tasks/task_b_689320ea7060832fa7578ffe3b50c85f