### PR TITLE
feat: show build link only for admin users

### DIFF
--- a/apps/client/src/components/NavBar.vue
+++ b/apps/client/src/components/NavBar.vue
@@ -30,7 +30,14 @@
         <router-link class="navbar-item" to="/about" @click="closeMenu">About</router-link>
         <router-link class="navbar-item" to="/faq" @click="closeMenu">FAQ</router-link>
         <router-link  class="navbar-item" to="/profile" @click="closeMenu">Profile</router-link>
-                <router-link  class="navbar-item" to="/build" @click="closeMenu">Build</router-link>
+        <router-link
+          v-if="user?.isAdmin"
+          class="navbar-item"
+          to="/build"
+          @click="closeMenu"
+        >
+          Build
+        </router-link>
 
       </div>
 


### PR DESCRIPTION
## Summary
- show build link in navbar only when an admin user is logged in

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6893515eb3a0832f84fbc0c7cf7192fe