### PR TITLE
fix: resume scene before restart

### DIFF
--- a/apps/client/src/components/games/ZoneRevealScene.ts
+++ b/apps/client/src/components/games/ZoneRevealScene.ts
@@ -403,6 +403,7 @@ for (let i = 0; i < 5; i++) {
       else this.scene.pause();
     };
     const handleRestart = () => {
+      if (this.scene.isPaused()) this.scene.resume();
       this.currentLevel = 0;
       this.lives = 3;
       this.score = 0;


### PR DESCRIPTION
## Summary
- resume GameScene before restarting to avoid pausing a non-running scene

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build:client`


------
https://chatgpt.com/codex/tasks/task_b_6894a3e982fc832fb3176b7dba417408