### PR TITLE
Hide page chrome during ZoneReveal gameplay

### DIFF
--- a/apps/client/src/components/games/ZoneRevealScene.ts
+++ b/apps/client/src/components/games/ZoneRevealScene.ts
@@ -442,6 +442,8 @@ for (let i = 0; i < 5; i++) {
       }
       swipeStart = null;
     });
+
+    window.dispatchEvent(new Event('gameStart'));
   }
 
   private loadLevel(levelIndex: number) {

--- a/apps/client/src/views/games/ZoneReveal.vue
+++ b/apps/client/src/views/games/ZoneReveal.vue
@@ -54,6 +54,16 @@ const showEndScreen = ref(false)
 const endScreenScore = ref(0)
 const answerRevealUTC = ref('')
 
+function hideChrome() {
+  document.querySelector('.navbar')?.classList.add('is-hidden')
+  document.querySelector('footer.footer')?.classList.add('is-hidden')
+}
+
+function showChrome() {
+  document.querySelector('.navbar')?.classList.remove('is-hidden')
+  document.querySelector('footer.footer')?.classList.remove('is-hidden')
+}
+
 useHead({
   title: `TOP-X: ${gameTitle.value || 'Zone Reveal Game'}`,
   meta: [
@@ -62,6 +72,8 @@ useHead({
 })
 
 onMounted(async () => {
+  hideChrome()
+  window.addEventListener('gameStart', hideChrome)
   if (!phaserContainer.value) return
 
   if (analytics) {
@@ -170,11 +182,14 @@ onBeforeUnmount(() => {
     game = null
   }
   window.removeEventListener('gameOver', handleGameOver)
+  window.removeEventListener('gameStart', hideChrome)
+  showChrome()
 })
 function handleGameOver(e: Event) {
   const customEvent = e as CustomEvent<{ score: number; totalTime: number }>
   endScreenScore.value = customEvent.detail.score
   showEndScreen.value = true
+  showChrome()
   if (game && game.scene.isActive('GameScene')) {
     game.scene.pause('GameScene') // Ensure paused
   }


### PR DESCRIPTION
## Summary
- Hide nav bar and footer while Zone Reveal game runs and restore them on game end
- Emit `gameStart` from Phaser scene so page chrome can be toggled after restarts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build --workspace=apps/client`

------
https://chatgpt.com/codex/tasks/task_b_68a4e3e4bdbc832fa2774a79e43c7235