### PR TITLE
feat: prevent mobile scrolling in Zone Reveal

### DIFF
--- a/apps/client/src/components/games/ZoneRevealScene.ts
+++ b/apps/client/src/components/games/ZoneRevealScene.ts
@@ -259,6 +259,12 @@ this.hiddenImage = this.add.image(innerX, innerY, `hidden0`)
 
     this.physics.world.setBounds(0, 0, WIDTH, HEIGHT);
     this.cursors = this.input.keyboard!.createCursorKeys();
+    this.input.keyboard!.addCapture([
+      Phaser.Input.Keyboard.KeyCodes.UP,
+      Phaser.Input.Keyboard.KeyCodes.DOWN,
+      Phaser.Input.Keyboard.KeyCodes.LEFT,
+      Phaser.Input.Keyboard.KeyCodes.RIGHT
+    ]);
 
     if (!this.anims.exists('move')) {
       this.anims.create({

--- a/apps/client/src/views/games/ZoneReveal.vue
+++ b/apps/client/src/views/games/ZoneReveal.vue
@@ -58,16 +58,30 @@ const showEndScreen = ref(false)
 const endScreenScore = ref(0)
 const answerRevealUTC = ref('')
 
+function preventScroll(e: Event) {
+  e.preventDefault()
+}
+
+function disableScroll() {
+  document.addEventListener('touchmove', preventScroll, { passive: false })
+}
+
+function enableScroll() {
+  document.removeEventListener('touchmove', preventScroll)
+}
+
 function hideChrome() {
   document.querySelector('.navbar')?.classList.add('is-hidden')
   document.querySelector('footer.footer')?.classList.add('is-hidden')
   document.body.style.overflow = 'hidden'
+  disableScroll()
 }
 
 function showChrome() {
   document.querySelector('.navbar')?.classList.remove('is-hidden')
   document.querySelector('footer.footer')?.classList.remove('is-hidden')
   document.body.style.overflow = ''
+  enableScroll()
 }
 
 function goBack() {
@@ -230,6 +244,7 @@ function restartGame() {
   align-items: center;
   height: 100vh;
   overflow: hidden;
+  touch-action: none;
 }
 
 .game-header {
@@ -253,6 +268,7 @@ function restartGame() {
   max-width: 500px;
   border: 2px solid #333;
   box-sizing: border-box;
+  touch-action: none;
 }
 .actions {
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- block touch scrolling by preventing default touchmove and adding `touch-action: none` styles
- capture arrow keys to avoid browser scroll during gameplay

## Testing
- `npm -w apps/client run build` *(terminated early: build started but did not complete due to environment limits)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68a500883554832fb6e0b98c5dedbbc0