### PR TITLE
feat: attempt fullscreen on zone reveal game

### DIFF
--- a/apps/client/src/components/games/ZoneRevealScene.ts
+++ b/apps/client/src/components/games/ZoneRevealScene.ts
@@ -437,8 +437,13 @@ for (let i = 0; i < 5; i++) {
     });
 
     let swipeStart: Phaser.Math.Vector2 | null = null;
+    let started = false;
     this.input.on('pointerdown', (p: Phaser.Input.Pointer) => {
       swipeStart = new Phaser.Math.Vector2(p.x, p.y);
+      if (!started) {
+        window.dispatchEvent(new Event('gameStart'));
+        started = true;
+      }
     });
     this.input.on('pointerup', (p: Phaser.Input.Pointer) => {
       if (!swipeStart) return;
@@ -452,8 +457,6 @@ for (let i = 0; i < 5; i++) {
       }
       swipeStart = null;
     });
-
-    window.dispatchEvent(new Event('gameStart'));
   }
 
   private loadLevel(levelIndex: number) {

--- a/apps/client/src/views/games/ZoneReveal.vue
+++ b/apps/client/src/views/games/ZoneReveal.vue
@@ -117,16 +117,26 @@ function hideChrome() {
   document.querySelector('.navbar')?.classList.add('is-hidden')
   document.querySelector('footer.footer')?.classList.add('is-hidden')
   document.body.style.overflow = 'hidden'
-      enableScroll()
-
+  // try to enter fullscreen so mobile browsers hide their UI chrome
+  const docEl: any = document.documentElement
+  const requestFull = docEl.requestFullscreen || docEl.webkitRequestFullscreen || docEl.mozRequestFullScreen || docEl.msRequestFullscreen
+  try {
+    requestFull?.call(docEl)
+  } catch (err) {
+    console.warn('Fullscreen request failed', err)
+  }
+  enableScroll()
 }
 
 function showChrome() {
   document.querySelector('.navbar')?.classList.remove('is-hidden')
   document.querySelector('footer.footer')?.classList.remove('is-hidden')
   document.body.style.overflow = ''
-    enableScroll()
-
+  // exit fullscreen if we previously entered it
+  if (document.fullscreenElement) {
+    document.exitFullscreen().catch(() => {})
+  }
+  enableScroll()
 }
 
 function goBack() {


### PR DESCRIPTION
## Summary
- request fullscreen and hide nav/footer when starting Zone Reveal to minimize mobile browser UI
- trigger fullscreen on first touch from game scene for user gesture compliance

## Testing
- `npm run build --workspace=apps/client`

------
https://chatgpt.com/codex/tasks/task_b_68a5059ed9cc832fbfea347f263867c0