### PR TITLE
feat: enhance zone reveal loading and messaging

### DIFF
--- a/apps/client/src/components/games/ZoneRevealScene.ts
+++ b/apps/client/src/components/games/ZoneRevealScene.ts
@@ -212,6 +212,27 @@ export default class VolfiedScene extends Phaser.Scene {
   }
 
   preload() {
+    const loadingText = this.add
+      .text(WIDTH / 2, HEIGHT / 2 - 25, 'Loading...', {
+        font: '20px Arial',
+        color: '#ffffff'
+      })
+      .setOrigin(0.5);
+    const progressBox = this.add.graphics();
+    progressBox.fillStyle(0x222222, 0.8);
+    progressBox.fillRect(WIDTH / 2 - 160, HEIGHT / 2 - 10, 320, 20);
+    const progressBar = this.add.graphics();
+    this.load.on('progress', value => {
+      progressBar.clear();
+      progressBar.fillStyle(0xffffff, 1);
+      progressBar.fillRect(WIDTH / 2 - 150, HEIGHT / 2 - 8, 300 * value, 16);
+    });
+    this.load.on('complete', () => {
+      progressBar.destroy();
+      progressBox.destroy();
+      loadingText.destroy();
+    });
+
     this.load.image('bg', this.zoneRevealConfig.backgroundImage ?? '/assets/anonymous.png');
     this.zoneRevealConfig.levelsConfig.forEach((level, index) => {
       this.load.image(`hidden${index}`, level.hiddenImage);
@@ -457,6 +478,7 @@ for (let i = 0; i < 5; i++) {
       }
       swipeStart = null;
     });
+    this.events.emit('ready');
   }
 
   private loadLevel(levelIndex: number) {
@@ -1028,16 +1050,27 @@ this.enemyGroup.children.entries.forEach((enemyObj) => {
 });
 this.enemyGroup.clear(true, true);
 
-      const winText = this.add.text(WIDTH / 2 - 60, HEIGHT / 2, 'Clue Unlocked! 🎉🔍', {
-        font: '24px Arial',
-        color: '#00ff00'
-      }).setDepth(3);
+      const winText = this.add
+        .text(WIDTH / 2, HEIGHT / 2, 'Clue Unlocked! 🎉🔍', {
+          font: '24px Arial',
+          color: '#00ff00',
+          backgroundColor: 'rgba(0,0,0,0.7)',
+          padding: { x: 10, y: 5 },
+          align: 'center'
+        })
+        .setOrigin(0.5)
+        .setDepth(3);
 
       let countdown = 5;
-      const countdownText = this.add.text(WIDTH / 2, HEIGHT / 2 + 40, `${countdown}`, {
-        font: '24px Arial',
-        color: '#ffffff'
-      }).setOrigin(0.5).setDepth(3);
+      const countdownText = this.add
+        .text(WIDTH / 2, HEIGHT / 2 + 40, `${countdown}`, {
+          font: '24px Arial',
+          color: '#ffffff',
+          backgroundColor: 'rgba(0,0,0,0.7)',
+          padding: { x: 8, y: 4 }
+        })
+        .setOrigin(0.5)
+        .setDepth(3);
       console.log('Starting countdown timer for level transition');
       this.time.addEvent({
         delay: 1000,

--- a/apps/client/src/views/games/ZoneReveal.vue
+++ b/apps/client/src/views/games/ZoneReveal.vue
@@ -32,6 +32,9 @@
     </div>
 
     <div ref="phaserContainer" class="phaser-container" />
+    <div v-if="isLoading" class="loading-overlay">
+      <div class="spinner"></div>
+    </div>
 
     <!-- X‑style D‑Pad -->
     <div class="controls">
@@ -112,6 +115,7 @@ const gameDescription = ref('')
 const showEndScreen = ref(false)
 const endScreenScore = ref(0)
 const answerRevealUTC = ref('')
+const isLoading = ref(true)
 
 function hideChrome() {
   document.querySelector('.navbar')?.classList.add('is-hidden')
@@ -228,6 +232,9 @@ onMounted(async () => {
   }
 
   const scene = new ZoneRevealScene(zoneRevealConfig.value || undefined)
+  scene.events.once('ready', () => {
+    isLoading.value = false
+  })
   game = new Phaser.Game({
     type: Phaser.AUTO,
     width: WIDTH,
@@ -312,6 +319,7 @@ function restartGame() { window.dispatchEvent(new Event('restartGame')) }
   overflow: hidden;
   background: var(--x-bg);
   color: var(--x-text);
+  position: relative;
 }
 
 .game-header {
@@ -398,6 +406,37 @@ function restartGame() { window.dispatchEvent(new Event('restartGame')) }
 .pad { touch-action: none; display: grid; gap: 10px; grid-template-columns: repeat(3, var(--size)); grid-auto-rows: var(--size); }
 .pad .spacer { visibility: hidden; }
 .row { display: flex; gap: 10px; margin: 8px 0; }
+
+.loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 10;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid var(--x-accent);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
 .actions { margin-top: 10px; display: flex; gap: 10px; flex-wrap: wrap; }
 
 /* Remove old generic button styling */


### PR DESCRIPTION
## Summary
- add in-scene loading progress bar and emit ready event
- show spinner overlay while game scene loads
- style win and countdown text with background for readability

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a5093230b8832f97d1b43614910d2a