### PR TITLE
feat(builder): add new zone reveal enemies and powerups

### DIFF
--- a/apps/client/src/components/build/AddZoneReveal.vue
+++ b/apps/client/src/components/build/AddZoneReveal.vue
@@ -178,9 +178,9 @@ const config = ref<ZoneRevealConfig>({
   heartIcon: '',
 });
 
-const enemyTypes = ['bouncing', 'robot', 'microbe'];
-const powerupTypes = ['extralive', 'extratime'];
-const spriteKeys = ['player', 'enemy', 'robot', 'microbe', 'heart', 'clock'];
+const enemyTypes = ['bouncing', 'robot', 'microbe', 'straightUp', 'straightLeft'];
+const powerupTypes = ['extralive', 'extratime', 'speed', 'freeze'];
+const spriteKeys = ['player', 'enemy', 'robot', 'microbe', 'straightUp', 'straightLeft', 'heart', 'clock', 'speed', 'freeze'];
 
 const newSpriteKey = ref('');
 const newSpriteValue = ref('');


### PR DESCRIPTION
## Summary
- expose speed and freeze powerups in zone reveal builder
- allow straightUp and straightLeft enemy types and spritesheets

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a5dbd6a574832f9c3a46b9736c24bc