### PR TITLE
fix: prevent profile reload loop

### DIFF
--- a/apps/client/src/views/Profile.vue
+++ b/apps/client/src/views/Profile.vue
@@ -365,8 +365,9 @@ function searchMoreFrenemies() {
   router.push('/frenemies');
 }
 
+
 watch(
-  [() => route.query.user, () => userStore.profile],
+  [() => route.query.user, () => userStore.user?.uid],
   async () => {
     await loadProfile();
     await loadPyramid();
@@ -380,6 +381,15 @@ watch(
     }
   },
   { immediate: true }
+);
+
+watch(
+  () => userStore.profile,
+  (newProfile) => {
+    if (isOwnProfile.value) {
+      profile.value = newProfile;
+    }
+  }
 );
 
 watch(activeTab, (newTab) => {


### PR DESCRIPTION
## Summary
- ensure previous Firestore profile listeners are cleaned up before starting a new one
- watch user changes in Profile view to avoid repeated reloads while still syncing profile data

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68bd7a477b70832faab4523c219b39dd